### PR TITLE
fix(#24): docs audit requires size + SHA-256 equality before flagging duplicates

### DIFF
--- a/scripts/audit-frontmatter-by-filename.js
+++ b/scripts/audit-frontmatter-by-filename.js
@@ -5,6 +5,12 @@
  * Scans all .md files in the workspace, extracts YAML frontmatter, and writes
  * a filename-based report in JSON and Markdown.
  *
+ * Duplicate detection requires BOTH:
+ *   1. Equal byte sizes (cheap first gate — different sizes = different content)
+ *   2. Equal SHA-256 hash (content confirmation)
+ * Files with the same name but different content are reported as
+ * "same-name / different-content" (informational), never as duplicates.
+ *
  * Usage:
  *   node scripts/audit-frontmatter-by-filename.js
  *
@@ -15,6 +21,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const ROOT = path.resolve(__dirname, '..');
 const DATA_DIR = path.join(ROOT, 'data');
@@ -132,6 +139,19 @@ function toRel(filePath) {
   return path.relative(ROOT, filePath).replace(/\\/g, '/');
 }
 
+/**
+ * Compute SHA-256 of a file's content.
+ * Returns null on read error so callers can skip gracefully.
+ */
+function sha256OfFile(filePath) {
+  try {
+    const buf = fs.readFileSync(filePath);
+    return crypto.createHash('sha256').update(buf).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
 function pad2(n) {
   return String(n).padStart(2, '0');
 }
@@ -152,29 +172,49 @@ function buildMarkdownReport(rows, summary) {
   lines.push(`- With frontmatter: ${summary.withFrontmatter}`);
   lines.push(`- Without frontmatter: ${summary.withoutFrontmatter}`);
   lines.push(`- Frontmatter parse errors: ${summary.errors}`);
-  lines.push(`- Duplicate filenames: ${summary.duplicateFilenames}`);
+  lines.push(`- True duplicates (same name + same content): ${summary.duplicateFilenames}`);
+  lines.push(`- Same name / different content (informational): ${summary.sameNameDifferentContent.length}`);
   lines.push('');
   lines.push('## Files');
   lines.push('');
-  lines.push('| Filename | Path | Frontmatter | Field Count | Keys | Error |');
-  lines.push('|---|---|---:|---:|---|---|');
+  lines.push('| Filename | Path | Bytes | Frontmatter | Field Count | Keys | Error |');
+  lines.push('|---|---|---:|---|---:|---|---|');
 
   for (const row of rows) {
     const keys = row.keys.join(', ');
-    lines.push(`| ${row.filename} | ${row.path} | ${row.hasFrontmatter ? 'yes' : 'no'} | ${row.fieldCount} | ${keys} | ${row.error || ''} |`);
+    lines.push(`| ${row.filename} | ${row.path} | ${row.bytes} | ${row.hasFrontmatter ? 'yes' : 'no'} | ${row.fieldCount} | ${keys} | ${row.error || ''} |`);
   }
 
   lines.push('');
-  lines.push('## Duplicate Filenames');
+  lines.push('## True Duplicates (same name AND same content)');
+  lines.push('');
+  lines.push('Files listed here are byte-for-byte identical — safe to deduplicate.');
   lines.push('');
 
   if (summary.duplicateFilenameDetails.length === 0) {
     lines.push('- None');
   } else {
     for (const d of summary.duplicateFilenameDetails) {
-      lines.push(`- ${d.filename}`);
+      lines.push(`- **${d.filename}** (${d.bytes} bytes)`);
       for (const p of d.paths) {
         lines.push(`  - ${p}`);
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('## Same Name / Different Content (informational)');
+  lines.push('');
+  lines.push('These files share a filename but have different content. They are NOT duplicates.');
+  lines.push('');
+
+  if (summary.sameNameDifferentContent.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const d of summary.sameNameDifferentContent) {
+      lines.push(`- **${d.filename}**`);
+      for (const e of d.entries) {
+        lines.push(`  - ${e.path} (${e.bytes} bytes)`);
       }
     }
   }
@@ -194,14 +234,20 @@ function main() {
     const parsed = parseFrontmatter(content);
     const keys = Object.keys(parsed.fields).sort((a, b) => a.localeCompare(b));
 
+    let bytes = 0;
+    try { bytes = fs.statSync(filePath).size; } catch { /* best-effort */ }
+
     return {
       filename: path.basename(filePath),
       path: toRel(filePath),
+      bytes,
       hasFrontmatter: parsed.hasFrontmatter,
       fieldCount: keys.length,
       keys,
       fields: parsed.fields,
       error: parsed.error,
+      // _absPath is used internally for hashing — not written to JSON
+      _absPath: filePath,
     };
   });
 
@@ -213,21 +259,86 @@ function main() {
     return a.path.localeCompare(b.path);
   });
 
+  // ── Duplicate detection: name match + size gate + SHA-256 confirmation ──
+  //
+  // Two files are TRUE DUPLICATES only when:
+  //   1. Same filename
+  //   2. Same byte size (cheap gate — different sizes = different content)
+  //   3. Same SHA-256 hash (content confirmation)
+  //
+  // Files with the same name but different size/content are "same-name /
+  // different-content" — informational, NOT flagged as duplicates.
+
   const filenameMap = new Map();
   for (const row of rows) {
     if (!filenameMap.has(row.filename)) {
       filenameMap.set(row.filename, []);
     }
-    filenameMap.get(row.filename).push(row.path);
+    filenameMap.get(row.filename).push(row);
   }
 
   const duplicateFilenameDetails = [];
-  for (const [filename, paths] of filenameMap.entries()) {
-    if (paths.length > 1) {
-      duplicateFilenameDetails.push({ filename, paths: paths.slice().sort((a, b) => a.localeCompare(b)) });
+  const sameNameDifferentContent = [];
+
+  for (const [filename, entries] of filenameMap.entries()) {
+    if (entries.length < 2) continue;
+
+    // Group entries by byte size first (cheap gate)
+    const sizeGroups = new Map();
+    for (const entry of entries) {
+      const key = entry.bytes;
+      if (!sizeGroups.has(key)) sizeGroups.set(key, []);
+      sizeGroups.get(key).push(entry);
+    }
+
+    // Within each size group, confirm by SHA-256
+    for (const sizeGroup of sizeGroups.values()) {
+      if (sizeGroup.length < 2) continue;
+
+      const hashGroups = new Map();
+      for (const entry of sizeGroup) {
+        const h = sha256OfFile(entry._absPath) ?? '__hash_error__';
+        if (!hashGroups.has(h)) hashGroups.set(h, []);
+        hashGroups.get(h).push(entry);
+      }
+
+      for (const [, hashGroup] of hashGroups.entries()) {
+        if (hashGroup.length >= 2) {
+          duplicateFilenameDetails.push({
+            filename,
+            bytes: hashGroup[0].bytes,
+            paths: hashGroup.map((e) => e.path).sort((a, b) => a.localeCompare(b)),
+          });
+        }
+      }
+    }
+
+    // Any entries NOT in a true-duplicate group → same-name / different-content
+    // Build a set of paths that ended up in a true-duplicate group
+    const dupPaths = new Set(
+      duplicateFilenameDetails
+        .filter((d) => d.filename === filename)
+        .flatMap((d) => d.paths),
+    );
+    const differentEntries = entries.filter((e) => !dupPaths.has(e.path));
+    if (differentEntries.length >= 2) {
+      sameNameDifferentContent.push({
+        filename,
+        entries: differentEntries
+          .map((e) => ({ path: e.path, bytes: e.bytes }))
+          .sort((a, b) => a.path.localeCompare(b.path)),
+      });
+    } else if (differentEntries.length === 1 && dupPaths.size > 0) {
+      // One entry didn't match any duplicate group — still different-content
+      sameNameDifferentContent.push({
+        filename,
+        entries: [{ path: differentEntries[0].path, bytes: differentEntries[0].bytes }],
+      });
     }
   }
+
   duplicateFilenameDetails.sort((a, b) => a.filename.localeCompare(b.filename));
+  sameNameDifferentContent.sort((a, b) => a.filename.localeCompare(b.filename));
 
   const summary = {
     total: rows.length,
@@ -236,27 +347,32 @@ function main() {
     errors: rows.filter((r) => !!r.error).length,
     duplicateFilenames: duplicateFilenameDetails.length,
     duplicateFilenameDetails,
+    sameNameDifferentContent,
   };
+
+  // Strip internal _absPath before writing JSON
+  const reportFiles = rows.map(({ _absPath: _ignored, ...rest }) => rest);
 
   const report = {
     generatedAt: new Date().toISOString(),
     root: ROOT,
     summary,
-    files: rows,
+    files: reportFiles,
   };
 
   const jsonPath = path.join(DATA_DIR, 'frontmatter-audit-by-filename.json');
   fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
 
   const mdPath = path.join(TODAY_DIR, `frontmatter-audit-${dateStamp(new Date())}.md`);
-  fs.writeFileSync(mdPath, buildMarkdownReport(rows, summary), 'utf8');
+  fs.writeFileSync(mdPath, buildMarkdownReport(reportFiles, summary), 'utf8');
 
   console.log('Frontmatter audit complete.');
   console.log(`Scanned: ${summary.total} markdown files`);
   console.log(`With frontmatter: ${summary.withFrontmatter}`);
   console.log(`Without frontmatter: ${summary.withoutFrontmatter}`);
   console.log(`Parse errors: ${summary.errors}`);
-  console.log(`Duplicate filenames: ${summary.duplicateFilenames}`);
+  console.log(`True duplicates (same name + same content): ${summary.duplicateFilenames}`);
+  console.log(`Same name / different content: ${summary.sameNameDifferentContent.length}`);
   console.log(`JSON report: ${toRel(jsonPath)}`);
   console.log(`Markdown report: ${toRel(mdPath)}`);
 }


### PR DESCRIPTION
## Summary
- `scripts/audit-frontmatter-by-filename.js` now requires **both** byte-size equality **and** SHA-256 hash equality before classifying two files as duplicates
- Files with matching names but differing content are classified as `sameNameDifferentContent` (informational) — never as duplicates
- Adds `bytes` field to each file row in the output

Fixes DiskCleanUp issue CieloVistaSoftware/DiskCleanUp#24 where files with clearly different byte counts (e.g. `index.md` at 1,561 vs 2,601 bytes) were incorrectly flagged as duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)