### PR TITLE
fix(#35,#36,#24): playwright.config.ts, MCP Viewer sortable headers, docs audit dedup fix

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './tests/ui',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: 'html',
+    use: {
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+});

--- a/scripts/audit-frontmatter-by-filename.js
+++ b/scripts/audit-frontmatter-by-filename.js
@@ -5,6 +5,12 @@
  * Scans all .md files in the workspace, extracts YAML frontmatter, and writes
  * a filename-based report in JSON and Markdown.
  *
+ * Duplicate detection requires BOTH:
+ *   1. Equal byte sizes (cheap first gate — different sizes = different content)
+ *   2. Equal SHA-256 hash (content confirmation)
+ * Files with the same name but different content are reported as
+ * "same-name / different-content" (informational), never as duplicates.
+ *
  * Usage:
  *   node scripts/audit-frontmatter-by-filename.js
  *
@@ -15,6 +21,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const ROOT = path.resolve(__dirname, '..');
 const DATA_DIR = path.join(ROOT, 'data');
@@ -132,6 +139,19 @@ function toRel(filePath) {
   return path.relative(ROOT, filePath).replace(/\\/g, '/');
 }
 
+/**
+ * Compute SHA-256 of a file's content.
+ * Returns null on read error so callers can skip gracefully.
+ */
+function sha256OfFile(filePath) {
+  try {
+    const buf = fs.readFileSync(filePath);
+    return crypto.createHash('sha256').update(buf).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
 function pad2(n) {
   return String(n).padStart(2, '0');
 }
@@ -152,29 +172,49 @@ function buildMarkdownReport(rows, summary) {
   lines.push(`- With frontmatter: ${summary.withFrontmatter}`);
   lines.push(`- Without frontmatter: ${summary.withoutFrontmatter}`);
   lines.push(`- Frontmatter parse errors: ${summary.errors}`);
-  lines.push(`- Duplicate filenames: ${summary.duplicateFilenames}`);
+  lines.push(`- True duplicates (same name + same content): ${summary.duplicateFilenames}`);
+  lines.push(`- Same name / different content (informational): ${summary.sameNameDifferentContent.length}`);
   lines.push('');
   lines.push('## Files');
   lines.push('');
-  lines.push('| Filename | Path | Frontmatter | Field Count | Keys | Error |');
-  lines.push('|---|---|---:|---:|---|---|');
+  lines.push('| Filename | Path | Bytes | Frontmatter | Field Count | Keys | Error |');
+  lines.push('|---|---|---:|---|---:|---|---|');
 
   for (const row of rows) {
     const keys = row.keys.join(', ');
-    lines.push(`| ${row.filename} | ${row.path} | ${row.hasFrontmatter ? 'yes' : 'no'} | ${row.fieldCount} | ${keys} | ${row.error || ''} |`);
+    lines.push(`| ${row.filename} | ${row.path} | ${row.bytes} | ${row.hasFrontmatter ? 'yes' : 'no'} | ${row.fieldCount} | ${keys} | ${row.error || ''} |`);
   }
 
   lines.push('');
-  lines.push('## Duplicate Filenames');
+  lines.push('## True Duplicates (same name AND same content)');
+  lines.push('');
+  lines.push('Files listed here are byte-for-byte identical — safe to deduplicate.');
   lines.push('');
 
   if (summary.duplicateFilenameDetails.length === 0) {
     lines.push('- None');
   } else {
     for (const d of summary.duplicateFilenameDetails) {
-      lines.push(`- ${d.filename}`);
+      lines.push(`- **${d.filename}** (${d.bytes} bytes)`);
       for (const p of d.paths) {
         lines.push(`  - ${p}`);
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('## Same Name / Different Content (informational)');
+  lines.push('');
+  lines.push('These files share a filename but have different content. They are NOT duplicates.');
+  lines.push('');
+
+  if (summary.sameNameDifferentContent.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const d of summary.sameNameDifferentContent) {
+      lines.push(`- **${d.filename}**`);
+      for (const e of d.entries) {
+        lines.push(`  - ${e.path} (${e.bytes} bytes)`);
       }
     }
   }
@@ -194,14 +234,20 @@ function main() {
     const parsed = parseFrontmatter(content);
     const keys = Object.keys(parsed.fields).sort((a, b) => a.localeCompare(b));
 
+    let bytes = 0;
+    try { bytes = fs.statSync(filePath).size; } catch { /* best-effort */ }
+
     return {
       filename: path.basename(filePath),
       path: toRel(filePath),
+      bytes,
       hasFrontmatter: parsed.hasFrontmatter,
       fieldCount: keys.length,
       keys,
       fields: parsed.fields,
       error: parsed.error,
+      // _absPath is used internally for hashing — not written to JSON
+      _absPath: filePath,
     };
   });
 
@@ -213,21 +259,86 @@ function main() {
     return a.path.localeCompare(b.path);
   });
 
+  // ── Duplicate detection: name match + size gate + SHA-256 confirmation ──
+  //
+  // Two files are TRUE DUPLICATES only when:
+  //   1. Same filename
+  //   2. Same byte size (cheap gate — different sizes = different content)
+  //   3. Same SHA-256 hash (content confirmation)
+  //
+  // Files with the same name but different size/content are "same-name /
+  // different-content" — informational, NOT flagged as duplicates.
+
   const filenameMap = new Map();
   for (const row of rows) {
     if (!filenameMap.has(row.filename)) {
       filenameMap.set(row.filename, []);
     }
-    filenameMap.get(row.filename).push(row.path);
+    filenameMap.get(row.filename).push(row);
   }
 
   const duplicateFilenameDetails = [];
-  for (const [filename, paths] of filenameMap.entries()) {
-    if (paths.length > 1) {
-      duplicateFilenameDetails.push({ filename, paths: paths.slice().sort((a, b) => a.localeCompare(b)) });
+  const sameNameDifferentContent = [];
+
+  for (const [filename, entries] of filenameMap.entries()) {
+    if (entries.length < 2) continue;
+
+    // Group entries by byte size first (cheap gate)
+    const sizeGroups = new Map();
+    for (const entry of entries) {
+      const key = entry.bytes;
+      if (!sizeGroups.has(key)) sizeGroups.set(key, []);
+      sizeGroups.get(key).push(entry);
+    }
+
+    // Within each size group, confirm by SHA-256
+    for (const sizeGroup of sizeGroups.values()) {
+      if (sizeGroup.length < 2) continue;
+
+      const hashGroups = new Map();
+      for (const entry of sizeGroup) {
+        const h = sha256OfFile(entry._absPath) ?? '__hash_error__';
+        if (!hashGroups.has(h)) hashGroups.set(h, []);
+        hashGroups.get(h).push(entry);
+      }
+
+      for (const [, hashGroup] of hashGroups.entries()) {
+        if (hashGroup.length >= 2) {
+          duplicateFilenameDetails.push({
+            filename,
+            bytes: hashGroup[0].bytes,
+            paths: hashGroup.map((e) => e.path).sort((a, b) => a.localeCompare(b)),
+          });
+        }
+      }
+    }
+
+    // Any entries NOT in a true-duplicate group → same-name / different-content
+    // Build a set of paths that ended up in a true-duplicate group
+    const dupPaths = new Set(
+      duplicateFilenameDetails
+        .filter((d) => d.filename === filename)
+        .flatMap((d) => d.paths),
+    );
+    const differentEntries = entries.filter((e) => !dupPaths.has(e.path));
+    if (differentEntries.length >= 2) {
+      sameNameDifferentContent.push({
+        filename,
+        entries: differentEntries
+          .map((e) => ({ path: e.path, bytes: e.bytes }))
+          .sort((a, b) => a.path.localeCompare(b.path)),
+      });
+    } else if (differentEntries.length === 1 && dupPaths.size > 0) {
+      // One entry didn't match any duplicate group — still different-content
+      sameNameDifferentContent.push({
+        filename,
+        entries: [{ path: differentEntries[0].path, bytes: differentEntries[0].bytes }],
+      });
     }
   }
+
   duplicateFilenameDetails.sort((a, b) => a.filename.localeCompare(b.filename));
+  sameNameDifferentContent.sort((a, b) => a.filename.localeCompare(b.filename));
 
   const summary = {
     total: rows.length,
@@ -236,27 +347,32 @@ function main() {
     errors: rows.filter((r) => !!r.error).length,
     duplicateFilenames: duplicateFilenameDetails.length,
     duplicateFilenameDetails,
+    sameNameDifferentContent,
   };
+
+  // Strip internal _absPath before writing JSON
+  const reportFiles = rows.map(({ _absPath: _ignored, ...rest }) => rest);
 
   const report = {
     generatedAt: new Date().toISOString(),
     root: ROOT,
     summary,
-    files: rows,
+    files: reportFiles,
   };
 
   const jsonPath = path.join(DATA_DIR, 'frontmatter-audit-by-filename.json');
   fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
 
   const mdPath = path.join(TODAY_DIR, `frontmatter-audit-${dateStamp(new Date())}.md`);
-  fs.writeFileSync(mdPath, buildMarkdownReport(rows, summary), 'utf8');
+  fs.writeFileSync(mdPath, buildMarkdownReport(reportFiles, summary), 'utf8');
 
   console.log('Frontmatter audit complete.');
   console.log(`Scanned: ${summary.total} markdown files`);
   console.log(`With frontmatter: ${summary.withFrontmatter}`);
   console.log(`Without frontmatter: ${summary.withoutFrontmatter}`);
   console.log(`Parse errors: ${summary.errors}`);
-  console.log(`Duplicate filenames: ${summary.duplicateFilenames}`);
+  console.log(`True duplicates (same name + same content): ${summary.duplicateFilenames}`);
+  console.log(`Same name / different content: ${summary.sameNameDifferentContent.length}`);
   console.log(`JSON report: ${toRel(jsonPath)}`);
   console.log(`Markdown report: ${toRel(mdPath)}`);
 }

--- a/src/features/mcp-viewer/html.ts
+++ b/src/features/mcp-viewer/html.ts
@@ -63,7 +63,10 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;f
 
 /* Tables */
 table{width:100%;border-collapse:collapse;font-size:12px;margin-bottom:12px}
-th{position:sticky;top:0;background:#252526;padding:7px 10px;text-align:left;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:#858585;border-bottom:1px solid #404040;white-space:nowrap;z-index:1}
+th{position:sticky;top:0;background:#252526;padding:7px 10px;text-align:left;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:#858585;border-bottom:1px solid #404040;white-space:nowrap;z-index:1;cursor:pointer;user-select:none}
+th:hover{color:#d4d4d4}
+th[data-sort="asc"]::after{content:' \\25b2';color:#9cdcfe;font-size:9px}
+th[data-sort="desc"]::after{content:' \\25bc';color:#9cdcfe;font-size:9px}
 td{padding:6px 10px;border-bottom:1px solid #2d2d2d;vertical-align:top}
 tr:hover td{background:#252526}
 
@@ -1021,6 +1024,33 @@ resultEl.addEventListener('click', function(e){
   var btn = e.target.closest('[data-action="open-project-catalog"]');
   if (!btn) { return; }
   openProjectCatalog(btn.dataset.project || '');
+});
+
+/* Table sort — event delegation handles all th clicks across all rendered tables. */
+resultEl.addEventListener('click', function(e){
+  var th = e.target.closest('th');
+  if (!th) { return; }
+  var tbl = th.closest('table');
+  if (!tbl) { return; }
+  var ths = Array.from(tbl.querySelectorAll('thead th'));
+  var ci  = ths.indexOf(th);
+  if (ci < 0) { return; }
+  var cur = th.getAttribute('data-sort');
+  var dir = cur === 'asc' ? -1 : 1;
+  ths.forEach(function(h){ h.removeAttribute('data-sort'); });
+  th.setAttribute('data-sort', dir === 1 ? 'asc' : 'desc');
+  var tbody = tbl.querySelector('tbody');
+  if (!tbody) { return; }
+  var rows = Array.from(tbody.querySelectorAll('tr'));
+  rows.sort(function(a, b){
+    var ta = (a.cells[ci] ? a.cells[ci].textContent : '') || '';
+    var tb = (b.cells[ci] ? b.cells[ci].textContent : '') || '';
+    var na = parseFloat(ta.replace(/[^0-9.]/g, ''));
+    var nb = parseFloat(tb.replace(/[^0-9.]/g, ''));
+    if (!isNaN(na) && !isNaN(nb)) { return dir * (na - nb); }
+    return dir * ta.localeCompare(tb);
+  });
+  rows.forEach(function(r){ tbody.appendChild(r); });
 });
 
 /* Initial load. */


### PR DESCRIPTION
## Summary

- **#35** — Added `playwright.config.ts` at the cielovista-tools repo root so the project is no longer flagged as missing Playwright setup
- **#36** — All MCP Viewer column headers are now sortable (click to sort ascending/descending)
- **#24** — Docs audit now requires both size equality AND SHA-256 hash match before flagging files as duplicates — eliminates false positives from same-size but different-content files

## Test plan

- [ ] `playwright.config.ts` present at repo root
- [ ] MCP Viewer: click any column header → sorts that column; click again → reverses
- [ ] Docs audit: two same-size but different-content files are NOT flagged as duplicates
- [ ] All 94 regression tests pass (run `node scripts/run-regression-tests.js`)

Closes #35
Closes #36
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)