### PR TITLE
feat: land issue-viewer #605/#601/#591/#602 + state pill, #592 corequisite fix, dup-images crash fix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,14 @@
       "Bash(node tests/unit/registry-promote.test.js)",
       "Bash(git checkout *)",
       "mcp__vscode-claude-runner__powershell_command",
-      "Bash(node tests/unit/frontmatter-header.test.js)"
+      "Bash(node tests/unit/frontmatter-header.test.js)",
+      "Bash(ls -la \"C:\\\\Users\\\\jwpmi\\\\Downloads\\\\VSCode\\\\projects\\\\DiskCleanUp\" | head -20)",
+      "Bash(xargs grep -l \"DiskCleanUp\")",
+      "PowerShell(gh repo view CieloVistaSoftware/disk-cleanup --json defaultBranchRef,url 2>&1)",
+      "PowerShell(head -5)",
+      "PowerShell(gh issue list --repo CieloVistaSoftware/disk-cleanup --state open --limit 20)",
+      "PowerShell(gh repo clone CieloVistaSoftware/DiskCleanUp \"$env:TEMP\\\\dc-check\" --depth 5 2>&1; git -C \"$env:TEMP\\\\dc-check\" log --oneline -15)",
+      "mcp__Claude_Preview__preview_start"
     ]
   }
 }

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -150,6 +150,14 @@ async function buildExtension() {
     format:      'cjs',
     sourcemap:   false,
   });
+  // Standalone install-command — no vscode dep, consumed by REG-117 unit test
+  await esbuild.build({
+    ...nodeBase,
+    entryPoints: ['src/shared/install-command.ts'],
+    outfile:     'out/shared/install-command.js',
+    format:      'cjs',
+    sourcemap:   false,
+  });
   // Copy doc-catalog HTML shell for playwright UI tests
   fs.mkdirSync('out/features/doc-catalog', { recursive: true });
   fs.copyFileSync(

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -90,6 +90,14 @@ async function buildExtension() {
     format:      'cjs',
     sourcemap:   false,
   });
+  // Standalone corequisite decision logic — no vscode dep, consumed by unit tests
+  await esbuild.build({
+    ...nodeBase,
+    entryPoints: ['src/shared/corequisite-logic.ts'],
+    outfile:     'out/shared/corequisite-logic.js',
+    format:      'cjs',
+    sourcemap:   false,
+  });
   // Standalone doc-auditor scanner — no vscode dep, consumed by unit tests
   await esbuild.build({
     ...nodeBase,

--- a/src/features/background-health-runner.ts
+++ b/src/features/background-health-runner.ts
@@ -104,6 +104,9 @@ let _running = false;
 let _panel: vscode.WebviewPanel | undefined;
 let _testRunTimer: NodeJS.Timeout | undefined;
 let _testRunInProgress = false;
+// Dedupe guard for saveState failures — a momentarily locked data dir (e.g. an
+// antivirus/OneDrive lock) used to auto-file an APP_ERROR on every 30s tick (#601).
+let _saveFailedLogged = false;
 
 // Last logged pass/fail per check — used to emit delta-only output
 const _checkStatus = new Map<string, 'pass' | 'fail'>();
@@ -138,12 +141,24 @@ function loadState(): void {
 }
 
 function saveState(): void {
-    try {
-        ensureDataDir();
-        _state.lastRun = new Date().toISOString();
-        fs.writeFileSync(HEALTH_FILE, JSON.stringify(_state, null, 2), 'utf8');
-    } catch (e) {
-        logError('Failed to save health state', e instanceof Error ? e.stack || String(e) : String(e), FEATURE);
+    _state.lastRun = new Date().toISOString();
+    const payload = JSON.stringify(_state, null, 2);
+    // Retry to ride out a transient lock on the data dir; only the final attempt
+    // reports. Persistent failure is logged once per streak (reset on recovery)
+    // so a locked dir does not spam APP_ERROR / auto-file every tick (#601).
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+            ensureDataDir();
+            fs.writeFileSync(HEALTH_FILE, payload, 'utf8');
+            _saveFailedLogged = false;
+            return;
+        } catch (e) {
+            if (attempt < 3) { continue; }
+            if (!_saveFailedLogged) {
+                _saveFailedLogged = true;
+                logError('Failed to save health state', e instanceof Error ? e.stack || String(e) : String(e), FEATURE);
+            }
+        }
     }
 }
 

--- a/src/features/corequisite-checker.README.md
+++ b/src/features/corequisite-checker.README.md
@@ -1,33 +1,64 @@
 # Feature: Corequisite Checker
 
-## Commands
-
-| Command ID | Title | Keybinding |
-|---|---|---|
-| `cvs.corequisites.check` | Check Corequisite Extensions | — |
-| `cvs.corequisites.install` | Install Missing Corequisite Extensions | — |
-
 ## What it does
 
 Reads the `cieloRequires` block from `package.json` and verifies that each declared peer extension is installed at the required minimum version. Offers one-click install via the VS Code extension API (with a CLI fallback). A silent background check runs automatically 3 seconds after activation to catch missing dependencies early.
 
+**Status states** (decided by the pure, vscode-free `shared/corequisite-logic.ts`): `ok`, `outdated`, `missing`, `unknown-version`, and `pending-reload`. A freshly-installed extension is present on disk but not yet visible in the live VS Code registry until the window reloads — it is reported as `pending-reload`, **not** `missing`, so the checker no longer false-positives a re-install loop or auto-files an APP_ERROR right after a successful install (issue #602).
+
 ---
-| [`cvs.corequisites.check`](command: cvs.corequisites.check) | Corequisites: Check |
-| [`cvs.corequisites.install`](command: cvs.corequisites.install) | Corequisites: Install |
-└── Corequisites: Install → cvs.corequisites.install
-**Key internal functions: **
+
+## Commands
+
+| Command ID | Title |
+|---|---|
+| [`cvs.corequisites.check`](command:cvs.corequisites.check) | Corequisites: Check |
+| [`cvs.corequisites.install`](command:cvs.corequisites.install) | Corequisites: Install |
+
+---
+
+## Internal architecture
+
+```text
+activate(context)
+  └── registers 2 command(s)
+  └── Corequisites: Check → cvs.corequisites.check
+  └── Corequisites: Install → cvs.corequisites.install
+```
+
+**Key internal functions:**
+- `readCieloRequires()`
+- `installedVersionOnDisk()` — scans the extensions folder via `shared/corequisite-logic.installedVersionFromDirNames()`
+- `checkOne()` — gathers live-registry + on-disk inputs, delegates to `shared/corequisite-logic.decideStatus()`
+- `messageFor()`
+- `findCodeInsidersBin()`
+- `installViaCli()`
+- `offerInstall()`
+- `runInstall()`
+- `runCheck()`
+
+**Pure logic** lives in `src/shared/corequisite-logic.ts` (no vscode, no fs) and is unit-tested with injected data by `tests/regression/REG-113-corequisite-pending-reload.test.js`.
+
+---
+
+## Manual test
+
 1. Open the Command Palette and run **Corequisites: Check** (`cvs.corequisites.check`).
+   Verify the expected output/panel opens with no errors in the CieloVista Tools output channel.
 2. Open the Command Palette and run **Corequisites: Install** (`cvs.corequisites.install`).
+   Verify the expected output/panel opens with no errors in the CieloVista Tools output channel.
+
+---
 docid: 150.1.corequisite-checker
 id: feature-corequisite-checker
-title: Feature: Corequisite Checker
+title: "Feature: Corequisite Checker"
 project: cielovista-tools
-description: Corequisite Checker — 2 command(s). Auto-generated stub: fill in What it does and Manual test.
+description: "Corequisite Checker — 2 command(s). Auto-generated stub: fill in What it does and Manual test."
 status: active
-tags: [checker, corequisite, cvs.corequisites.check, cvs.corequisites.install]
+tags: [corequisite, checker]
 category: 150.1 — Components / Features
 created: 2026-05-15
-updated: 2026-05-15
+updated: 2026-06-14
 version: 1.0.0
 author: CieloVista Software
 relativepath: src/features/corequisite-checker.README.md

--- a/src/features/corequisite-checker.ts
+++ b/src/features/corequisite-checker.ts
@@ -28,16 +28,14 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as cp from 'child_process';
 import { log, logError } from '../shared/output-channel';
+import {
+    decideStatus,
+    installedVersionFromDirNames,
+    type CorequisiteSpec,
+    type Status,
+} from '../shared/corequisite-logic';
 
 const FEATURE = 'corequisite-checker';
-
-interface CorequisiteSpec {
-    minVersion?: string;
-    displayName?: string;
-    vsixPath?: string;
-}
-
-type Status = 'ok' | 'missing' | 'outdated' | 'unknown-version';
 
 interface CheckResult {
     id: string;
@@ -47,19 +45,12 @@ interface CheckResult {
     message: string;
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────
-
-/** Numeric compare of two semver-shaped strings (no pre-release handling). */
-function compareVersions(a: string, b: string): number {
-    const pa = a.split('.').map(n => parseInt(n, 10) || 0);
-    const pb = b.split('.').map(n => parseInt(n, 10) || 0);
-    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-        const da = pa[i] || 0;
-        const db = pb[i] || 0;
-        if (da !== db) return da - db;
-    }
-    return 0;
+/** A corequisite needs user action only when it is missing or outdated. */
+function isProblem(status: Status): boolean {
+    return status === 'missing' || status === 'outdated';
 }
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
 
 /** Read the cieloRequires block from this extension's package.json. */
 function readCieloRequires(extensionPath: string): Record<string, CorequisiteSpec> {
@@ -75,26 +66,43 @@ function readCieloRequires(extensionPath: string): Record<string, CorequisiteSpe
     }
 }
 
-/** Check one declared peer against the live VS Code extension registry. */
-function checkOne(id: string, spec: CorequisiteSpec): CheckResult {
+/** Scan the extensions folder for an installed-on-disk version of `id`. */
+function installedVersionOnDisk(id: string, extensionsDir: string): string | undefined {
+    try {
+        const names = fs.readdirSync(extensionsDir, { withFileTypes: true })
+            .filter(e => e.isDirectory())
+            .map(e => e.name);
+        return installedVersionFromDirNames(id, names);
+    } catch {
+        return undefined;
+    }
+}
+
+/** Human-readable status message for a checked corequisite. */
+function messageFor(id: string, spec: CorequisiteSpec, status: Status, installedVersion?: string): string {
+    const name = spec.displayName || id;
+    switch (status) {
+        case 'ok':              return `${name} v${installedVersion} OK`;
+        case 'pending-reload':  return `${name} v${installedVersion} installed — reload window to activate`;
+        case 'outdated':        return `${name} v${installedVersion} is below required v${spec.minVersion}`;
+        case 'unknown-version': return `${id} is installed but version is unreadable`;
+        case 'missing':         return `${name} is not installed`;
+    }
+}
+
+/**
+ * Check one declared peer. The live registry is authoritative, but a freshly
+ * installed extension is not visible there until the window reloads (#602), so
+ * fall back to an on-disk scan and report `pending-reload` instead of `missing`.
+ */
+function checkOne(id: string, spec: CorequisiteSpec, extensionsDir: string): CheckResult {
     const ext = vscode.extensions.getExtension(id);
-    if (!ext) {
-        return { id, spec, status: 'missing', message: `${spec.displayName || id} is not installed` };
-    }
-    const installedVersion: string | undefined = ext.packageJSON?.version;
-    if (!installedVersion) {
-        return { id, spec, status: 'unknown-version', message: `${id} is installed but version is unreadable` };
-    }
-    if (spec.minVersion && compareVersions(installedVersion, spec.minVersion) < 0) {
-        return {
-            id, spec, status: 'outdated', installedVersion,
-            message: `${spec.displayName || id} v${installedVersion} is below required v${spec.minVersion}`
-        };
-    }
-    return {
-        id, spec, status: 'ok', installedVersion,
-        message: `${spec.displayName || id} v${installedVersion} OK`
-    };
+    const registryPresent = !!ext;
+    const registryVersion: string | undefined = ext?.packageJSON?.version;
+    const diskVersion = registryPresent ? undefined : installedVersionOnDisk(id, extensionsDir);
+
+    const { status, installedVersion } = decideStatus({ spec, registryPresent, registryVersion, diskVersion });
+    return { id, spec, status, installedVersion, message: messageFor(id, spec, status, installedVersion) };
 }
 
 /** Locate code-insiders.cmd on disk; falls back to PATH lookup. */
@@ -212,11 +220,14 @@ async function runCheck(
         log(FEATURE, 'No cieloRequires entries — nothing to check.');
         return [];
     }
-    const results = ids.map(id => checkOne(id, requires[id]));
+    // The extensions folder is this extension's own parent directory — robust
+    // across stable/insiders without hardcoding a profile path.
+    const extensionsDir = path.dirname(extensionPath);
+    const results = ids.map(id => checkOne(id, requires[id], extensionsDir));
     for (const r of results) {
         log(FEATURE, `[${r.status.toUpperCase()}] ${r.message}`);
     }
-    const problems = results.filter(r => r.status === 'missing' || r.status === 'outdated');
+    const problems = results.filter(r => isProblem(r.status));
     if (problems.length === 0 && options.silentIfClean) return results;
 
     if (options.autoInstall) {
@@ -240,11 +251,11 @@ export function activate(context: vscode.ExtensionContext): void {
                 vscode.window.showInformationMessage('No corequisites declared in package.json.');
                 return;
             }
-            const ok = results.filter(r => r.status === 'ok');
-            const problems = results.filter(r => r.status !== 'ok');
+            const fine = results.filter(r => r.status === 'ok' || r.status === 'pending-reload');
+            const problems = results.filter(r => isProblem(r.status));
             if (problems.length === 0) {
-                const summary = ok.map(r => `${r.spec.displayName || r.id} v${r.installedVersion}`).join(', ');
-                vscode.window.showInformationMessage(`All ${ok.length} corequisite extension(s) OK: ${summary}`);
+                const summary = fine.map(r => `${r.spec.displayName || r.id} v${r.installedVersion}${r.status === 'pending-reload' ? ' (reload to activate)' : ''}`).join(', ');
+                vscode.window.showInformationMessage(`All ${fine.length} corequisite extension(s) OK: ${summary}`);
             }
         }),
         vscode.commands.registerCommand('cvs.corequisites.install', async () => {

--- a/src/features/corequisite-checker.ts
+++ b/src/features/corequisite-checker.ts
@@ -34,6 +34,7 @@ import {
     type CorequisiteSpec,
     type Status,
 } from '../shared/corequisite-logic';
+import { buildInstallCommand } from '../shared/install-command';
 
 const FEATURE = 'corequisite-checker';
 
@@ -118,14 +119,16 @@ function findCodeInsidersBin(): string {
 }
 
 function installViaCli(bin: string, vsix: string): string {
-    const args = ['--install-extension', vsix];
-    // Use shell:true for .cmd/.bat so Windows resolves them correctly without
-    // manual cmd.exe /c quoting (which breaks on paths with spaces).
-    const useShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(bin);
-    const result = cp.spawnSync(bin, args, {
+    // A .cmd/.bat shim must run through a shell, but shell:true does NOT
+    // auto-quote — an unquoted binary path with spaces (the real
+    // code-insiders.cmd lives under "Microsoft VS Code Insiders") is split by
+    // cmd.exe and fails with "'...\Microsoft' is not recognized" (#592).
+    // buildInstallCommand emits a fully-quoted command line in that case.
+    const { command, args, shell } = buildInstallCommand(bin, vsix);
+    const result = cp.spawnSync(command, args, {
             encoding: 'utf8',
             windowsHide: true,
-            shell: useShell,
+            shell,
         });
 
     if (result.error) {

--- a/src/features/notify-server.ts
+++ b/src/features/notify-server.ts
@@ -54,7 +54,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
     _server.on('error', (err: NodeJS.ErrnoException) => {
         if (err.code === 'EADDRINUSE') {
-            logError('Notify server: port 52199 already in use — another instance may be running', err instanceof Error ? err.stack || String(err) : String(err), FEATURE);
+            // Expected when another CVT window already owns the notify bridge.
+            // Use log() — output channel only — rather than the persisted error
+            // log, which auto-files an APP_ERROR for this benign condition (#591).
+            log(FEATURE, `⚠ Notify bridge port ${PORT} already in use — another CVT window owns it; this window will not start a second bridge.`);
         } else {
             logError('Notify server error', err instanceof Error ? err.stack || String(err) : String(err), FEATURE);
         }

--- a/src/shared/corequisite-logic.ts
+++ b/src/shared/corequisite-logic.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// Unauthorized copying or distribution of this file is strictly prohibited.
+
+// component: aud
+
+/**
+ * corequisite-logic.ts
+ *
+ * Pure, vscode-free decision logic for the corequisite checker.
+ * Lives in shared/ so it can be unit-tested with injected data — no VS Code
+ * registry, no filesystem. The feature file (corequisite-checker.ts) gathers
+ * the live inputs and delegates every decision to the functions here.
+ *
+ * Issue #602: a freshly-installed extension is present on disk but is NOT yet
+ * visible in the live VS Code registry (vscode.extensions.getExtension) until
+ * the window reloads. The checker used to read the registry only, so the very
+ * next check after a successful install reported the extension as `missing`,
+ * causing a false-positive APP_ERROR and a re-install loop. decideStatus() now
+ * accepts an on-disk version too and reports `pending-reload` instead.
+ */
+
+export type Status = 'ok' | 'missing' | 'outdated' | 'unknown-version' | 'pending-reload';
+
+export interface CorequisiteSpec {
+    minVersion?: string;
+    displayName?: string;
+    vsixPath?: string;
+}
+
+export interface DecideInput {
+    spec: CorequisiteSpec;
+    /** True when vscode.extensions.getExtension(id) returned an extension. */
+    registryPresent: boolean;
+    /** Version reported by the live registry (undefined if absent/unreadable). */
+    registryVersion?: string;
+    /** Version found by scanning the extensions folder on disk (undefined if none). */
+    diskVersion?: string;
+}
+
+export interface Decision {
+    status: Status;
+    installedVersion?: string;
+}
+
+/** Numeric compare of two semver-shaped strings (no pre-release handling). */
+export function compareVersions(a: string, b: string): number {
+    const pa = a.split('.').map(n => parseInt(n, 10) || 0);
+    const pb = b.split('.').map(n => parseInt(n, 10) || 0);
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+        const da = pa[i] || 0;
+        const db = pb[i] || 0;
+        if (da !== db) { return da - db; }
+    }
+    return 0;
+}
+
+/**
+ * Given a list of extension directory names of the form
+ * `<publisher>.<name>-<version>`, return the highest installed version for `id`,
+ * or undefined when none match. Used to detect an extension that is installed
+ * on disk but not yet loaded into the live registry.
+ */
+export function installedVersionFromDirNames(id: string, dirNames: string[]): string | undefined {
+    const prefix = id.toLowerCase() + '-';
+    let best: string | undefined;
+    for (const name of dirNames) {
+        const lower = name.toLowerCase();
+        if (!lower.startsWith(prefix)) { continue; }
+        const ver = name.slice(prefix.length);
+        // The remainder must start with a version number — guards against a
+        // sibling id like "<id>-extra-1.0.0" being mistaken for a version.
+        if (!/^\d+(\.\d+)*$/.test(ver)) { continue; }
+        if (!best || compareVersions(ver, best) > 0) { best = ver; }
+    }
+    return best;
+}
+
+/**
+ * Decide a corequisite's status from the live-registry and on-disk inputs.
+ * The live registry is authoritative when the extension is present there.
+ */
+export function decideStatus(input: DecideInput): Decision {
+    const { spec, registryPresent, registryVersion, diskVersion } = input;
+
+    // The live registry is authoritative whenever the extension is loaded.
+    if (registryPresent) {
+        if (!registryVersion) { return { status: 'unknown-version' }; }
+        if (spec.minVersion && compareVersions(registryVersion, spec.minVersion) < 0) {
+            return { status: 'outdated', installedVersion: registryVersion };
+        }
+        return { status: 'ok', installedVersion: registryVersion };
+    }
+
+    // #602: not in the live registry, but the VSIX is unpacked on disk — it was
+    // just installed and the host has not reloaded yet. That is pending-reload,
+    // NOT missing. Still flag it outdated if the on-disk build is too old.
+    if (diskVersion) {
+        if (spec.minVersion && compareVersions(diskVersion, spec.minVersion) < 0) {
+            return { status: 'outdated', installedVersion: diskVersion };
+        }
+        return { status: 'pending-reload', installedVersion: diskVersion };
+    }
+
+    return { status: 'missing' };
+}

--- a/src/shared/github-issues-view.ts
+++ b/src/shared/github-issues-view.ts
@@ -258,6 +258,8 @@ export function showGithubIssues(viewColumn: vscode.ViewColumn = vscode.ViewColu
             void vscode.env.clipboard.writeText(formatIssuesForClipboard(latestIssues));
         } else if (msg.type === 'claim' && msg.number) {
             void claimIssue(msg.number, panel);
+        } else if (msg.type === 'answered' && msg.number) {
+            void answeredIssue(msg.number, panel);
         } else if (msg.type === 'runTest' && msg.testRef) {
             void runLinkedTest(String(msg.testRef));
         } else if (msg.type === 'openLocal' && typeof (msg as { relativePath?: string }).relativePath === 'string') {
@@ -286,6 +288,22 @@ async function claimIssue(number: number, panel: vscode.WebviewPanel): Promise<v
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         void vscode.window.showErrorMessage(`Failed to claim issue #${number}: ${msg}`);
+    }
+}
+
+// ─── Answered (clear Question status) ────────────────────────────────────────
+
+async function answeredIssue(number: number, panel: vscode.WebviewPanel): Promise<void> {
+    const run = (args: string[]) => new Promise<void>((resolve, reject) => {
+        execFile('gh', args, { shell: true }, (err) => err ? reject(err) : resolve());
+    });
+    try {
+        await run(['issue', 'edit', String(number), '--remove-label', 'status:question', '--repo', `${currentRepo.owner}/${currentRepo.name}`]);
+        panel.webview.postMessage({ type: 'answered', number });
+        void vscode.window.showInformationMessage(`Issue #${number} — status:question cleared.`);
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        void vscode.window.showErrorMessage(`Failed to clear question on #${number}: ${msg}`);
     }
 }
 
@@ -687,7 +705,16 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
 .state-pill{display:inline-block;padding:1px 7px;border-radius:10px;font-size:10px;font-weight:700;border:1px solid;white-space:nowrap}
 .state-pill.open{background:rgba(88,166,255,.14);color:#58a6ff;border-color:rgba(88,166,255,.45)}
 .state-pill.in-progress{background:rgba(240,180,41,.18);color:#f0b429;border-color:rgba(240,180,41,.5)}
+.state-pill.question{background:rgba(163,113,247,.16);color:#a371f7;border-color:rgba(163,113,247,.5)}
 .state-pill.closed{background:rgba(63,185,80,.14);color:#3fb950;border-color:rgba(63,185,80,.45)}
+.q-banner{display:flex;align-items:center;gap:10px;margin:0 0 10px;padding:8px 12px;border-radius:8px;background:rgba(163,113,247,.12);border:1px solid rgba(163,113,247,.4);font-size:12px;color:#c8a8f9}
+.q-banner strong{color:#a371f7}
+.q-banner button{margin-left:auto;padding:3px 10px;border-radius:10px;font-size:11px;font-weight:600;background:rgba(163,113,247,.18);color:#c8a8f9;border:1px solid rgba(163,113,247,.5);cursor:pointer;font-family:inherit}
+.q-banner button + button{margin-left:6px}
+.q-banner button:hover{background:rgba(163,113,247,.32)}
+.answered-btn{padding:1px 8px;border-radius:10px;font-size:10px;font-weight:600;background:rgba(163,113,247,.14);color:#a371f7;border:1px solid rgba(163,113,247,.45);cursor:pointer;font-family:inherit;white-space:nowrap}
+.answered-btn:hover{background:rgba(163,113,247,.28)}
+.answered-btn:disabled{opacity:.5;cursor:wait}
 .claim-btn{margin-left:6px;padding:1px 7px;border-radius:10px;font-size:10px;font-weight:600;background:rgba(88,166,255,.14);color:#58a6ff;border:1px solid rgba(88,166,255,.45);cursor:pointer;font-family:inherit}
 .claim-btn:hover{background:rgba(88,166,255,.28)}
 .claim-btn:disabled{opacity:.5;cursor:wait}
@@ -731,13 +758,18 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
             // (John's convention for flagging active work).
             const isInProgress = iss.labels.some((l) => l.name === 'status:in-progress' || l.name === 'priority:1');
             const inProgressChip = isInProgress ? '<span class="in-progress-chip">in-progress</span>' : '';
+            // An issue is a Question when it is blocked on the user (status:question).
+            const isQuestion = iss.labels.some((l) => l.name === 'status:question');
             // State pill is a traffic light: open = blue (needs attention),
-            // in-progress = amber (being worked on), closed = green (resolved /
-            // all is well). gh returns state uppercase ("OPEN"), REST lowercase —
-            // normalise before comparing.
+            // in-progress = amber (being worked on), question = purple (blocked on
+            // the user), closed = green (resolved / all is well). gh returns state
+            // uppercase ("OPEN"), REST lowercase — normalise before comparing.
+            // Precedence: closed > question > in-progress > open, so a blocked
+            // issue shows QUESTION even when it is also active work.
             const isOpen = iss.state.toLowerCase() === 'open';
-            const statePillClass = !isOpen ? 'closed' : (isInProgress ? 'in-progress' : 'open');
-            const statePillText  = !isOpen ? 'CLOSED' : (isInProgress ? 'IN PROGRESS' : 'OPEN');
+            const statePillClass = !isOpen ? 'closed' : (isQuestion ? 'question' : (isInProgress ? 'in-progress' : 'open'));
+            const statePillText  = !isOpen ? 'CLOSED' : (isQuestion ? 'QUESTION' : (isInProgress ? 'IN PROGRESS' : 'OPEN'));
+            const isOpenQuestion = isOpen && isQuestion;
             const labels = iss.labels.filter((l) => !l.name.startsWith('project:')).map((l) => {
                 const bg = (l.color || '888888').replace(/^#/, '');
                 const fg = contrastText(bg);
@@ -762,6 +794,7 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
     data-author="${esc(iss.user.login.toLowerCase())}"
     data-project="${esc(projectName.toLowerCase())}"
     data-priority="3"
+    data-question="${isOpenQuestion ? '1' : '0'}"
     data-filter="${esc(filterText)}">
     <td class="num">#${iss.number}</td>
     <td>${inProgressChip}${labels ? `<span class="tags">${labels}</span>` : (isInProgress ? '' : `<span class="muted">-</span>`)}</td>
@@ -777,9 +810,16 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
     <td title="${esc(iss.created_at)}">${esc(ago(iss.created_at))}</td>
     <td title="${esc(iss.updated_at)}">${esc(ago(iss.updated_at))}</td>
     <td title="${iss.closed_at ? esc(iss.closed_at) : ''}">${esc(closedAtAgo)}</td>
-    <td><div class="actions-cell">${isOpen ? `<button class="start-work-btn" type="button" data-number="${iss.number}" data-title="${esc(iss.title)}" title="Set priority 1, create branch, open issue #${iss.number}">&#9654; Start Work</button>` : ''}${testRef ? `<button class="run-test-btn" type="button" data-number="${iss.number}" data-testref="${esc(testRef)}" title="Run ${esc(testRef)}">&#9654; Run Test</button>` : `<button class="run-test-btn" type="button" disabled title="No test linked">&#9654; Run Test</button>`}${fixLinksHtml || `<span class="muted">-</span>`}</div></td>
+    <td><div class="actions-cell">${isOpenQuestion ? `<button class="answered-btn" type="button" data-number="${iss.number}" title="Mark answered — removes status:question">&#10003; Answered</button>` : ''}${isOpen ? `<button class="start-work-btn" type="button" data-number="${iss.number}" data-title="${esc(iss.title)}" title="Set priority 1, create branch, open issue #${iss.number}">&#9654; Start Work</button>` : ''}${testRef ? `<button class="run-test-btn" type="button" data-number="${iss.number}" data-testref="${esc(testRef)}" title="Run ${esc(testRef)}">&#9654; Run Test</button>` : `<button class="run-test-btn" type="button" disabled title="No test linked">&#9654; Run Test</button>`}${fixLinksHtml || `<span class="muted">-</span>`}</div></td>
 </tr>`;
         }).join('');
+                // Surface issues blocked on the user so they can validate one by one.
+                const questionCount = issues.filter((i) =>
+                    i.state.toLowerCase() === 'open' && i.labels.some((l) => l.name === 'status:question')
+                ).length;
+                const qBanner = (viewState === 'open' && questionCount > 0)
+                    ? `<div class="q-banner"><span>&#10067; <strong>${questionCount}</strong> ${questionCount === 1 ? 'issue is' : 'issues are'} waiting on you</span><button id="q-filter-btn" type="button">Show questions</button><button id="q-clear-btn" type="button" style="display:none">Show all</button></div>`
+                    : '';
                 const table = `<div class="table-wrap"><table id="issuesTable"><thead><tr>
 <th><button type="button" data-sort="number">number <span class="sort-ind"></span></button></th>
 <th><button type="button" data-sort="labels">Status <span class="sort-ind"></span></button></th>
@@ -795,7 +835,7 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
 <th><button type="button" data-sort="closed">closed_at <span class="sort-ind"></span></button></th>
 <th>actions</th>
 </tr></thead><tbody id="issueRows">${rows}</tbody></table></div>`;
-                bodyHtml = summary + controls + table;
+                bodyHtml = summary + qBanner + controls + table;
     }
 
     const js = `
@@ -875,6 +915,7 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
         });
     }
 
+    var qOnly = false;
     function applyFilter(){
         var input = document.getElementById('search');
         var q = input ? String(input.value || '').trim().toLowerCase() : '';
@@ -888,7 +929,8 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
             var proj = String(row.dataset.project || '');
             var okText = !q || txt.indexOf(q) !== -1;
             var okProj = !projQ || proj === projQ;
-            var ok = okText && okProj;
+            var okQ = !qOnly || row.getAttribute('data-question') === '1';
+            var ok = okText && okProj && okQ;
             row.style.display = ok ? '' : 'none';
             if (ok) { shown++; }
         });
@@ -1048,6 +1090,33 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
             vsc.postMessage({ type: 'startWork', number: num, title: title });
         });
     });
+    document.querySelectorAll('.answered-btn').forEach(function(b){
+        b.addEventListener('click', function(){
+            var num = Number(b.getAttribute('data-number'));
+            if (!num) { return; }
+            b.disabled = true;
+            b.textContent = '…';
+            vsc.postMessage({ type: 'answered', number: num });
+        });
+    });
+    var qFilterBtn = document.getElementById('q-filter-btn');
+    var qClearBtn = document.getElementById('q-clear-btn');
+    if (qFilterBtn) {
+        qFilterBtn.addEventListener('click', function(){
+            qOnly = true;
+            qFilterBtn.style.display = 'none';
+            if (qClearBtn) { qClearBtn.style.display = ''; }
+            applyFilter();
+        });
+    }
+    if (qClearBtn) {
+        qClearBtn.addEventListener('click', function(){
+            qOnly = false;
+            qClearBtn.style.display = 'none';
+            if (qFilterBtn) { qFilterBtn.style.display = ''; }
+            applyFilter();
+        });
+    }
     window.addEventListener('message', function(ev){
         var m = ev.data || {};
         if (m.type === 'claimed') {
@@ -1056,6 +1125,11 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
         } else if (m.type === 'workStarted') {
             var swBtn = document.querySelector('.start-work-btn[data-number="' + m.number + '"]');
             if (swBtn) { swBtn.textContent = m.branch ? '✓ ' + m.branch : '✓ Branched'; swBtn.style.color = '#a371f7'; swBtn.style.borderColor = 'rgba(163,113,247,.45)'; }
+        } else if (m.type === 'answered') {
+            var qRow = document.querySelector('.issue-row[data-number="' + m.number + '"]');
+            if (qRow) { qRow.setAttribute('data-question', '0'); }
+            applyFilter();
+            setTimeout(function(){ vsc.postMessage({ type: 'refresh' }); }, 400);
         }
     });
     applySort();

--- a/src/shared/github-issues-view.ts
+++ b/src/shared/github-issues-view.ts
@@ -684,7 +684,10 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
 .tags{display:flex;gap:4px;flex-wrap:wrap}
 .label{padding:1px 7px;border-radius:10px;font-size:10px;font-weight:600;line-height:1.45;border:1px solid rgba(0,0,0,.1)}
 .priority{background:var(--vscode-dropdown-background, var(--vscode-input-background));color:var(--vscode-dropdown-foreground, var(--vscode-input-foreground));border:1px solid var(--vscode-dropdown-border, var(--vscode-panel-border));border-radius:4px;padding:2px 4px;font-size:11px}
-.state-pill{display:inline-block;padding:1px 7px;border-radius:10px;font-size:10px;font-weight:700;background:rgba(63,185,80,.14);color:#3fb950;border:1px solid rgba(63,185,80,.45)}
+.state-pill{display:inline-block;padding:1px 7px;border-radius:10px;font-size:10px;font-weight:700;border:1px solid;white-space:nowrap}
+.state-pill.open{background:rgba(88,166,255,.14);color:#58a6ff;border-color:rgba(88,166,255,.45)}
+.state-pill.in-progress{background:rgba(240,180,41,.18);color:#f0b429;border-color:rgba(240,180,41,.5)}
+.state-pill.closed{background:rgba(63,185,80,.14);color:#3fb950;border-color:rgba(63,185,80,.45)}
 .claim-btn{margin-left:6px;padding:1px 7px;border-radius:10px;font-size:10px;font-weight:600;background:rgba(88,166,255,.14);color:#58a6ff;border:1px solid rgba(88,166,255,.45);cursor:pointer;font-family:inherit}
 .claim-btn:hover{background:rgba(88,166,255,.28)}
 .claim-btn:disabled{opacity:.5;cursor:wait}
@@ -723,8 +726,18 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
                 const rows = issues.map((iss) => {
             const testRef   = extractTestRef(iss.body);
             const fixRefs   = viewState === 'closed' ? extractLocalFixRefs(iss) : [];
-            const isInProgress = iss.labels.some((l) => l.name === 'status:in-progress');
+            // An issue counts as "being worked on" when it carries the explicit
+            // status:in-progress label (set by Claim/Start Work) OR priority:1
+            // (John's convention for flagging active work).
+            const isInProgress = iss.labels.some((l) => l.name === 'status:in-progress' || l.name === 'priority:1');
             const inProgressChip = isInProgress ? '<span class="in-progress-chip">in-progress</span>' : '';
+            // State pill is a traffic light: open = blue (needs attention),
+            // in-progress = amber (being worked on), closed = green (resolved /
+            // all is well). gh returns state uppercase ("OPEN"), REST lowercase —
+            // normalise before comparing.
+            const isOpen = iss.state.toLowerCase() === 'open';
+            const statePillClass = !isOpen ? 'closed' : (isInProgress ? 'in-progress' : 'open');
+            const statePillText  = !isOpen ? 'CLOSED' : (isInProgress ? 'IN PROGRESS' : 'OPEN');
             const labels = iss.labels.filter((l) => !l.name.startsWith('project:')).map((l) => {
                 const bg = (l.color || '888888').replace(/^#/, '');
                 const fg = contrastText(bg);
@@ -745,7 +758,7 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
     data-updated="${new Date(iss.updated_at).getTime()}"
     data-closed="${closedAtTs}"
     data-comments="${iss.comments}"
-    data-state="${esc(iss.state.toLowerCase())}"
+    data-state="${esc(statePillClass)}"
     data-author="${esc(iss.user.login.toLowerCase())}"
     data-project="${esc(projectName.toLowerCase())}"
     data-priority="3"
@@ -757,14 +770,14 @@ tbody tr:hover{background:var(--vscode-list-hoverBackground)}
         <button class="title-btn" type="button" data-url="${esc(iss.html_url)}" title="Open #${iss.number} on GitHub">${esc(iss.title)}</button>
     </td>
     <td><select class="priority" data-number="${iss.number}" aria-label="Priority for issue #${iss.number}"><option value="1">1</option><option value="2">2</option><option value="3" selected>3</option><option value="4">4</option><option value="5">5</option></select></td>
-    <td><span class="state-pill">${esc(iss.state)}</span>${iss.state === 'open' ? `<button class="claim-btn" type="button" data-number="${iss.number}" title="Assign to me and set status:in-progress">Claim</button>` : ''}</td>
+    <td><span class="state-pill ${statePillClass}">${statePillText}</span>${isOpen ? `<button class="claim-btn" type="button" data-number="${iss.number}" title="Assign to me and set status:in-progress">Claim</button>` : ''}</td>
     <td><span class="muted">@${esc(iss.user.login)}</span></td>
     <td>${assigneesText ? `<span class="muted">${esc(assigneesText)}</span>` : `<span class="muted">-</span>`}</td>
     <td>${iss.comments}</td>
     <td title="${esc(iss.created_at)}">${esc(ago(iss.created_at))}</td>
     <td title="${esc(iss.updated_at)}">${esc(ago(iss.updated_at))}</td>
     <td title="${iss.closed_at ? esc(iss.closed_at) : ''}">${esc(closedAtAgo)}</td>
-    <td><div class="actions-cell">${iss.state === 'open' ? `<button class="start-work-btn" type="button" data-number="${iss.number}" data-title="${esc(iss.title)}" title="Set priority 1, create branch, open issue #${iss.number}">&#9654; Start Work</button>` : ''}${testRef ? `<button class="run-test-btn" type="button" data-number="${iss.number}" data-testref="${esc(testRef)}" title="Run ${esc(testRef)}">&#9654; Run Test</button>` : ''}${fixLinksHtml || `<span class="muted">-</span>`}</div></td>
+    <td><div class="actions-cell">${isOpen ? `<button class="start-work-btn" type="button" data-number="${iss.number}" data-title="${esc(iss.title)}" title="Set priority 1, create branch, open issue #${iss.number}">&#9654; Start Work</button>` : ''}${testRef ? `<button class="run-test-btn" type="button" data-number="${iss.number}" data-testref="${esc(testRef)}" title="Run ${esc(testRef)}">&#9654; Run Test</button>` : `<button class="run-test-btn" type="button" disabled title="No test linked">&#9654; Run Test</button>`}${fixLinksHtml || `<span class="muted">-</span>`}</div></td>
 </tr>`;
         }).join('');
                 const table = `<div class="table-wrap"><table id="issuesTable"><thead><tr>

--- a/src/shared/install-command.ts
+++ b/src/shared/install-command.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// Unauthorized copying or distribution of this file is strictly prohibited.
+/**
+ * install-command.ts
+ *
+ * Pure command-building logic for installing a VSIX through a
+ * `code` / `code-insiders` CLI binary. Extracted from corequisite-checker so
+ * it can be unit-tested without a live VS Code host (#592).
+ *
+ * Consumed by tests/regression/REG-117 via out/shared/install-command.js.
+ */
+
+export interface InstallCommand {
+    /** First argument to cp.spawnSync — a full command line when `shell`, else the bare binary. */
+    command: string;
+    /** Argument array — empty when `shell` (the command line carries everything). */
+    args: string[];
+    /** Whether spawnSync must run through a shell (cmd.exe). */
+    shell: boolean;
+}
+
+/** Quote a single token for safe use inside a cmd.exe command line. */
+export function shellQuote(token: string): string {
+    return `"${String(token).replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build the cp.spawnSync inputs to run `<bin> --install-extension <vsix>`.
+ *
+ * On Windows a `.cmd`/`.bat` shim must run through a shell, but Node does NOT
+ * auto-quote arguments when `shell:true` — so a binary path containing spaces
+ * (e.g. "...\Microsoft VS Code Insiders\bin\code-insiders.cmd") is split by
+ * cmd.exe at the first space, producing
+ *   "'...\Microsoft' is not recognized as an internal or external command"
+ * which surfaced to the user as "Failed to install Claude Chat" (#592).
+ *
+ * We therefore build a single, fully-quoted command line ourselves and leave
+ * the `--install-extension` flag bare. Bare executables (no .cmd/.bat) and
+ * non-Windows platforms keep the safer argv form (no shell, no manual quoting).
+ */
+export function buildInstallCommand(
+    bin: string,
+    vsix: string,
+    platform: NodeJS.Platform = process.platform,
+): InstallCommand {
+    const useShell = platform === 'win32' && /\.(cmd|bat)$/i.test(bin);
+    if (useShell) {
+        return {
+            command: `${shellQuote(bin)} --install-extension ${shellQuote(vsix)}`,
+            args: [],
+            shell: true,
+        };
+    }
+    return {
+        command: bin,
+        args: ['--install-extension', vsix],
+        shell: false,
+    };
+}

--- a/tests/regression/REG-112-issue-viewer-state-pill-traffic-light.test.js
+++ b/tests/regression/REG-112-issue-viewer-state-pill-traffic-light.test.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// REG-112: Issue Viewer state pill must be a traffic light, not always green.
+//
+// John's feedback (screenshot): green should mean "all is well", so an OPEN
+// issue must NOT be green. He also wants a distinct state for issues being
+// worked on. Required mapping:
+//   open        -> blue  (#58a6ff)  needs attention, nothing started
+//   in-progress -> amber (#f0b429)  being worked on (status:in-progress OR priority:1)
+//   closed      -> green (#3fb950)  resolved / all is well
+//
+// Regression guarded: the pill used to be a single hardcoded green class
+// rendering esc(iss.state) for every row.
+
+'use strict';
+
+const fs     = require('fs');
+const path   = require('path');
+const assert = require('assert');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SRC  = fs.readFileSync(
+    path.join(ROOT, 'src', 'shared', 'github-issues-view.ts'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try   { fn(); console.log(`  PASS ${name}`); passed++; }
+    catch (e) { console.error(`  FAIL ${name}\n       ${e.message}`); failed++; }
+}
+
+console.log('REG-112: Issue Viewer state pill — traffic light (open=blue, in-progress=amber, closed=green)');
+console.log('-'.repeat(70));
+
+test('state pill is no longer a single hardcoded-green rule', () => {
+    // The old CSS: .state-pill{...background:rgba(63,185,80,.14);color:#3fb950;...}
+    // i.e. green baked into the base .state-pill rule with no modifier class.
+    const baseRule = SRC.match(/\.state-pill\{[^}]*\}/)?.[0] ?? '';
+    assert.ok(baseRule, '.state-pill base rule not found');
+    assert.ok(
+        !/#3fb950/.test(baseRule) && !/63,185,80/.test(baseRule),
+        '.state-pill base rule must not hardcode green — color comes from a state modifier class'
+    );
+});
+
+test('open pill is blue (#58a6ff)', () => {
+    const rule = SRC.match(/\.state-pill\.open\{[^}]*\}/)?.[0] ?? '';
+    assert.ok(rule, '.state-pill.open rule not found');
+    assert.ok(/#58a6ff/i.test(rule), '.state-pill.open must use blue #58a6ff');
+});
+
+test('in-progress pill is amber (#f0b429)', () => {
+    const rule = SRC.match(/\.state-pill\.in-progress\{[^}]*\}/)?.[0] ?? '';
+    assert.ok(rule, '.state-pill.in-progress rule not found');
+    assert.ok(/#f0b429/i.test(rule), '.state-pill.in-progress must use amber #f0b429');
+});
+
+test('closed pill is green (#3fb950)', () => {
+    const rule = SRC.match(/\.state-pill\.closed\{[^}]*\}/)?.[0] ?? '';
+    assert.ok(rule, '.state-pill.closed rule not found');
+    assert.ok(/#3fb950/i.test(rule), '.state-pill.closed must use green #3fb950');
+});
+
+test('pill class is data-driven (statePillClass), not esc(iss.state)', () => {
+    assert.ok(
+        /class="state-pill \$\{statePillClass\}"/.test(SRC),
+        'state pill must render the computed statePillClass modifier'
+    );
+    assert.ok(
+        !/<span class="state-pill">\$\{esc\(iss\.state\)\}<\/span>/.test(SRC),
+        'state pill must not render the raw uppercased state with a class-less green pill'
+    );
+});
+
+test('statePillClass maps open/in-progress/closed correctly', () => {
+    const m = SRC.match(/const statePillClass\s*=\s*([^;]+);/);
+    assert.ok(m, 'statePillClass assignment not found');
+    const expr = m[1];
+    assert.ok(/'closed'/.test(expr),      'must map closed');
+    assert.ok(/'in-progress'/.test(expr), 'must map in-progress');
+    assert.ok(/'open'/.test(expr),        'must map open');
+});
+
+test('in-progress is triggered by status:in-progress OR priority:1', () => {
+    const m = SRC.match(/const isInProgress\s*=\s*iss\.labels\.some\([^;]+;/);
+    assert.ok(m, 'isInProgress assignment not found');
+    const expr = m[0];
+    assert.ok(/status:in-progress/.test(expr), 'must check status:in-progress label');
+    assert.ok(/priority:1/.test(expr),         'must also check priority:1 label');
+});
+
+test('open detection is case-insensitive (handles gh "OPEN" and REST "open")', () => {
+    assert.ok(
+        /iss\.state\.toLowerCase\(\)\s*===\s*'open'/.test(SRC),
+        'isOpen must normalise iss.state with toLowerCase() before comparing'
+    );
+    // The old strict checks iss.state === 'open' silently failed for gh's "OPEN".
+    assert.ok(
+        !/iss\.state === 'open'/.test(SRC),
+        'no remaining strict iss.state === \'open\' comparisons (case-sensitive bug)'
+    );
+});
+
+console.log('-'.repeat(70));
+if (failed === 0) {
+    console.log(`✓ REG-112 passed (${passed} checks).\n`);
+    process.exit(0);
+}
+console.error(`✗ REG-112 FAILED (${failed} of ${passed + failed} checks failed).\n`);
+process.exit(1);

--- a/tests/regression/REG-113-corequisite-pending-reload.test.js
+++ b/tests/regression/REG-113-corequisite-pending-reload.test.js
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// REG-113: Issue #602 — corequisite-checker must not report a just-installed
+// extension as "missing".
+//
+// Root cause: vscode.extensions.getExtension(id) does not see a freshly
+// installed extension until the window reloads. The checker read the live
+// registry only, so the startup background check ran a few seconds after a
+// successful install and reported the extension as `missing` — a false
+// positive that auto-filed an APP_ERROR and drove a re-install loop.
+//
+// Fix: decideStatus() also accepts an on-disk version (scanned from the
+// extensions folder). An extension present on disk but absent from the live
+// registry is `pending-reload`, not `missing`.
+//
+// This test exercises the REAL compiled module (out/shared/corequisite-logic.js)
+// with injected data — no VS Code, no filesystem. It self-heals by recompiling
+// when the artifact is missing or stale.
+
+'use strict';
+
+const fs      = require('fs');
+const path    = require('path');
+const assert  = require('assert');
+const { execSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SRC  = path.join(ROOT, 'src', 'shared', 'corequisite-logic.ts');
+const OUT  = path.join(ROOT, 'out', 'shared', 'corequisite-logic.js');
+
+// ── Ensure the compiled module is present and fresh ──────────────────────────
+function ensureCompiled() {
+    const needsBuild =
+        !fs.existsSync(OUT) ||
+        fs.statSync(SRC).mtimeMs > fs.statSync(OUT).mtimeMs;
+    if (needsBuild) {
+        execSync(`node "${path.join(ROOT, 'esbuild.mjs')}"`, { cwd: ROOT, stdio: 'pipe' });
+    }
+}
+ensureCompiled();
+
+const logic = require(OUT);
+const { decideStatus, installedVersionFromDirNames, compareVersions } = logic;
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try   { fn(); console.log(`  PASS ${name}`); passed++; }
+    catch (e) { console.error(`  FAIL ${name}\n       ${e.message}`); failed++; }
+}
+
+console.log('REG-113: corequisite-checker — on-disk extension is pending-reload, not missing (#602)');
+console.log('-'.repeat(70));
+
+const spec = { minVersion: '1.0.0', displayName: 'Claude Chat' };
+
+// ── The #602 regression itself ───────────────────────────────────────────────
+test('on disk but absent from live registry -> pending-reload (NOT missing)', () => {
+    const d = decideStatus({ spec, registryPresent: false, registryVersion: undefined, diskVersion: '1.0.0' });
+    assert.strictEqual(d.status, 'pending-reload',
+        `just-installed extension must be pending-reload, got '${d.status}'`);
+    assert.strictEqual(d.installedVersion, '1.0.0');
+});
+
+test('absent from registry AND absent from disk -> missing', () => {
+    const d = decideStatus({ spec, registryPresent: false, registryVersion: undefined, diskVersion: undefined });
+    assert.strictEqual(d.status, 'missing');
+});
+
+test('present in registry, meets minVersion -> ok', () => {
+    const d = decideStatus({ spec, registryPresent: true, registryVersion: '1.2.0', diskVersion: undefined });
+    assert.strictEqual(d.status, 'ok');
+    assert.strictEqual(d.installedVersion, '1.2.0');
+});
+
+test('present in registry, below minVersion -> outdated', () => {
+    const d = decideStatus({ spec, registryPresent: true, registryVersion: '0.9.0', diskVersion: undefined });
+    assert.strictEqual(d.status, 'outdated');
+});
+
+test('on disk but below minVersion -> outdated (not pending-reload)', () => {
+    const d = decideStatus({ spec, registryPresent: false, registryVersion: undefined, diskVersion: '0.9.0' });
+    assert.strictEqual(d.status, 'outdated');
+});
+
+test('present in registry but version unreadable -> unknown-version', () => {
+    const d = decideStatus({ spec, registryPresent: true, registryVersion: undefined, diskVersion: undefined });
+    assert.strictEqual(d.status, 'unknown-version');
+});
+
+test('live registry is authoritative over disk when both present', () => {
+    // Registry says 1.2.0 (ok); disk says 0.5.0. Registry wins.
+    const d = decideStatus({ spec, registryPresent: true, registryVersion: '1.2.0', diskVersion: '0.5.0' });
+    assert.strictEqual(d.status, 'ok');
+    assert.strictEqual(d.installedVersion, '1.2.0');
+});
+
+test('no minVersion requirement: on disk -> pending-reload', () => {
+    const d = decideStatus({ spec: { displayName: 'X' }, registryPresent: false, diskVersion: '0.0.1' });
+    assert.strictEqual(d.status, 'pending-reload');
+});
+
+// ── installedVersionFromDirNames ─────────────────────────────────────────────
+test('finds installed version from extension dir names', () => {
+    const dirs = [
+        'ms-python.python-2026.4.0',
+        'cielovistasoftware.vscode-claude-1.0.0',
+        'cielovistasoftware.cielovista-tools-1.0.2',
+    ];
+    assert.strictEqual(installedVersionFromDirNames('cielovistasoftware.vscode-claude', dirs), '1.0.0');
+});
+
+test('picks the highest version when multiple are present', () => {
+    const dirs = [
+        'cielovistasoftware.vscode-claude-1.0.0',
+        'cielovistasoftware.vscode-claude-1.2.0',
+        'cielovistasoftware.vscode-claude-1.0.5',
+    ];
+    assert.strictEqual(installedVersionFromDirNames('cielovistasoftware.vscode-claude', dirs), '1.2.0');
+});
+
+test('does not match a different id that shares a prefix', () => {
+    const dirs = ['cielovistasoftware.vscode-claude-extra-1.0.0'];
+    assert.strictEqual(installedVersionFromDirNames('cielovistasoftware.vscode-claude', dirs), undefined);
+});
+
+test('returns undefined when nothing matches', () => {
+    assert.strictEqual(installedVersionFromDirNames('foo.bar', ['baz.qux-1.0.0']), undefined);
+});
+
+test('match is case-insensitive (Windows extension folders)', () => {
+    const dirs = ['CieloVistaSoftware.VSCode-Claude-1.0.0'];
+    assert.strictEqual(installedVersionFromDirNames('cielovistasoftware.vscode-claude', dirs), '1.0.0');
+});
+
+test('compareVersions orders correctly', () => {
+    assert.ok(compareVersions('1.2.0', '1.0.0') > 0);
+    assert.ok(compareVersions('1.0.0', '1.0.1') < 0);
+    assert.strictEqual(compareVersions('1.0.0', '1.0.0'), 0);
+});
+
+console.log('-'.repeat(70));
+if (failed === 0) {
+    console.log(`✓ REG-113 passed (${passed} checks).\n`);
+    process.exit(0);
+}
+console.error(`✗ REG-113 FAILED (${failed} of ${passed + failed} checks failed).\n`);
+process.exit(1);

--- a/tests/regression/REG-114-issue-viewer-question-status.test.js
+++ b/tests/regression/REG-114-issue-viewer-question-status.test.js
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// REG-114: Issue Viewer "Question" status (#605).
+//
+// When work on an issue is blocked on the user (validate / answer / decide),
+// the issue carries status:question and must surface distinctly:
+//   - state pill: purple QUESTION (#a371f7), precedence closed > question >
+//     in-progress > open
+//   - a Questions banner listing how many issues await the user, with a filter
+//     to show only those rows so the user can validate one by one
+//   - a per-row "Answered" action that removes status:question
+
+'use strict';
+
+const fs     = require('fs');
+const path   = require('path');
+const assert = require('assert');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SRC  = fs.readFileSync(
+    path.join(ROOT, 'src', 'shared', 'github-issues-view.ts'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try   { fn(); console.log(`  PASS ${name}`); passed++; }
+    catch (e) { console.error(`  FAIL ${name}\n       ${e.message}`); failed++; }
+}
+
+console.log('REG-114: Issue Viewer — Question status pill, banner, filter, Answered action (#605)');
+console.log('-'.repeat(70));
+
+test('question pill CSS is purple (#a371f7)', () => {
+    const rule = SRC.match(/\.state-pill\.question\{[^}]*\}/)?.[0] ?? '';
+    assert.ok(rule, '.state-pill.question rule not found');
+    assert.ok(/#a371f7/i.test(rule), '.state-pill.question must use purple #a371f7');
+});
+
+test('isQuestion is detected from the status:question label', () => {
+    const m = SRC.match(/const isQuestion\s*=\s*iss\.labels\.some\([^;]+;/);
+    assert.ok(m, 'isQuestion assignment not found');
+    assert.ok(/status:question/.test(m[0]), 'isQuestion must check the status:question label');
+});
+
+test('state pill precedence is closed > question > in-progress > open', () => {
+    const m = SRC.match(/const statePillClass\s*=\s*([^;]+);/);
+    assert.ok(m, 'statePillClass assignment not found');
+    const expr = m[1];
+    assert.ok(/'question'/.test(expr), 'must map question');
+    // question must be evaluated before in-progress so a blocked-on-user issue
+    // shows QUESTION even when it is also active work.
+    const qIdx  = expr.indexOf('isQuestion');
+    const ipIdx = expr.indexOf('isInProgress');
+    assert.ok(qIdx !== -1 && ipIdx !== -1, 'both isQuestion and isInProgress must appear');
+    assert.ok(qIdx < ipIdx, 'isQuestion must be checked before isInProgress (precedence)');
+});
+
+test('rows expose data-question for filtering', () => {
+    assert.ok(/data-question="\$\{/.test(SRC), 'issue rows must carry a data-question attribute');
+});
+
+test('a Questions banner surfaces the count of issues awaiting the user', () => {
+    assert.ok(/q-banner/.test(SRC), 'a .q-banner element must be rendered');
+    assert.ok(/q-filter-btn/.test(SRC), 'banner must include a question-filter button');
+});
+
+test('applyFilter honours a questions-only mode via data-question', () => {
+    const fn = SRC.match(/function applyFilter\(\)\{[\s\S]*?\n    \}/)?.[0] ?? '';
+    assert.ok(fn, 'applyFilter function not found');
+    assert.ok(/data-question|qOnly/.test(fn), 'applyFilter must gate rows on the questions-only flag');
+});
+
+test('per-row Answered action posts an answered message', () => {
+    assert.ok(/answered-btn/.test(SRC), 'an .answered-btn must be rendered for question rows');
+    assert.ok(/type:\s*'answered'/.test(SRC), "Answered button must post { type: 'answered' }");
+});
+
+test('answered handler removes the status:question label', () => {
+    assert.ok(/msg\.type === 'answered'/.test(SRC), "message handler must handle type 'answered'");
+    assert.ok(
+        /--remove-label['"\s,]+.*status:question|status:question[\s\S]{0,40}--remove-label|'--remove-label',\s*'status:question'/.test(SRC),
+        'answered flow must remove the status:question label via gh'
+    );
+});
+
+console.log('-'.repeat(70));
+if (failed === 0) {
+    console.log(`✓ REG-114 passed (${passed} checks).\n`);
+    process.exit(0);
+}
+console.error(`✗ REG-114 FAILED (${failed} of ${passed + failed} checks failed).\n`);
+process.exit(1);

--- a/tests/regression/REG-115-notify-server-eaddrinuse-not-autofiled.test.js
+++ b/tests/regression/REG-115-notify-server-eaddrinuse-not-autofiled.test.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// REG-115: notify-server must not auto-file an APP_ERROR when the port is
+// already in use (#591).
+//
+// EADDRINUSE on 127.0.0.1:52199 just means another CVT window already owns the
+// notify bridge — an expected condition with multiple windows open. logError()
+// persists to the error log, which auto-files a GitHub issue, so an expected
+// condition must use log() (output channel only), not logError().
+
+'use strict';
+
+const fs     = require('fs');
+const path   = require('path');
+const assert = require('assert');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SRC  = fs.readFileSync(
+    path.join(ROOT, 'src', 'features', 'notify-server.ts'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try   { fn(); console.log(`  PASS ${name}`); passed++; }
+    catch (e) { console.error(`  FAIL ${name}\n       ${e.message}`); failed++; }
+}
+
+console.log('REG-115: notify-server — EADDRINUSE is not auto-filed (#591)');
+console.log('-'.repeat(70));
+
+// Isolate the EADDRINUSE branch body.
+function eaddrinuseBlock() {
+    const m = SRC.match(/if\s*\(\s*err\.code === 'EADDRINUSE'\s*\)\s*\{([\s\S]*?)\}\s*else/);
+    assert.ok(m, 'EADDRINUSE branch not found');
+    return m[1];
+}
+
+test('EADDRINUSE branch does NOT call logError (would auto-file)', () => {
+    assert.ok(
+        !/logError\s*\(/.test(eaddrinuseBlock()),
+        'EADDRINUSE must not use logError — it auto-files an APP_ERROR for an expected condition'
+    );
+});
+
+test('EADDRINUSE branch logs via log() instead', () => {
+    assert.ok(
+        /\blog\s*\(/.test(eaddrinuseBlock()),
+        'EADDRINUSE should still be recorded via log() to the output channel'
+    );
+});
+
+test('genuine (non-EADDRINUSE) server errors still use logError', () => {
+    // The else branch of the same error handler must keep logError.
+    const m = SRC.match(/'EADDRINUSE'[\s\S]*?else\s*\{([\s\S]*?)\}\s*\)\s*;/);
+    assert.ok(m, 'else branch of error handler not found');
+    assert.ok(/logError\s*\(/.test(m[1]), 'real server errors must still logError');
+});
+
+console.log('-'.repeat(70));
+if (failed === 0) {
+    console.log(`✓ REG-115 passed (${passed} checks).\n`);
+    process.exit(0);
+}
+console.error(`✗ REG-115 FAILED (${failed} of ${passed + failed} checks failed).\n`);
+process.exit(1);

--- a/tests/regression/REG-116-bg-health-savestate-retry-dedupe.test.js
+++ b/tests/regression/REG-116-bg-health-savestate-retry-dedupe.test.js
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// REG-116: bg-health saveState must not spam APP_ERROR on a transient write
+// failure (#601).
+//
+// Root: saveState() wrote bg-health.json and called logError() on every failure.
+// When the data dir was momentarily locked (e.g. an antivirus/OneDrive lock on
+// <repo>/data), each 30s tick auto-filed another APP_ERROR — "(×6)".
+//
+// Fix: retry the write a few times to ride out a transient lock, and dedupe the
+// failure log via a guard flag so a persistent failure is reported once per
+// streak (reset on recovery), not every tick. A persistently unwritable dir is
+// already surfaced separately by the chk-health-file health check.
+
+'use strict';
+
+const fs     = require('fs');
+const path   = require('path');
+const assert = require('assert');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SRC  = fs.readFileSync(
+    path.join(ROOT, 'src', 'features', 'background-health-runner.ts'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try   { fn(); console.log(`  PASS ${name}`); passed++; }
+    catch (e) { console.error(`  FAIL ${name}\n       ${e.message}`); failed++; }
+}
+
+console.log('REG-116: bg-health saveState — retry + dedupe failure logging (#601)');
+console.log('-'.repeat(70));
+
+function saveStateBody() {
+    const m = SRC.match(/function saveState\(\)\s*:\s*void\s*\{([\s\S]*?)\n\}/);
+    assert.ok(m, 'saveState function not found');
+    return m[1];
+}
+
+test('saveState retries the write (does not give up after one attempt)', () => {
+    const body = saveStateBody();
+    assert.ok(
+        /for\s*\(/.test(body) || /attempt/i.test(body) || /retr/i.test(body),
+        'saveState must retry the write to ride out a transient lock'
+    );
+});
+
+test('saveState dedupes failure logging via a guard flag', () => {
+    const body = saveStateBody();
+    // A module-level guard so the same persistent failure is not logged every tick.
+    assert.ok(
+        /_saveFailedLogged/.test(body),
+        'saveState must gate failure logging behind a dedupe flag (_saveFailedLogged)'
+    );
+    assert.ok(
+        /_saveFailedLogged/.test(SRC.match(/let _saveFailedLogged|const _saveFailedLogged|var _saveFailedLogged/)?.[0] ?? ''),
+        '_saveFailedLogged must be declared at module scope'
+    );
+});
+
+test('the dedupe flag resets on a successful write', () => {
+    const body = saveStateBody();
+    // After a successful write, clear the flag so a future failure is reported again.
+    assert.ok(
+        /_saveFailedLogged\s*=\s*false/.test(body),
+        'saveState must reset _saveFailedLogged to false on success'
+    );
+});
+
+test('failure path still records the error once (logError guarded by the flag)', () => {
+    const body = saveStateBody();
+    assert.ok(/logError\s*\(|log\s*\(/.test(body), 'persistent failure must still be recorded once');
+    // The logError/log on failure must be guarded by an if on the flag.
+    assert.ok(
+        /if\s*\(\s*!_saveFailedLogged\s*\)/.test(body),
+        'failure logging must be gated by `if (!_saveFailedLogged)`'
+    );
+});
+
+console.log('-'.repeat(70));
+if (failed === 0) {
+    console.log(`✓ REG-116 passed (${passed} checks).\n`);
+    process.exit(0);
+}
+console.error(`✗ REG-116 FAILED (${failed} of ${passed + failed} checks failed).\n`);
+process.exit(1);

--- a/tests/regression/REG-117-corequisite-install-quotes-spaced-path.test.js
+++ b/tests/regression/REG-117-corequisite-install-quotes-spaced-path.test.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 CieloVista Software. All rights reserved.
+// REG-117: Issue #592 — corequisite-checker "Failed to install Claude Chat".
+//
+// Root cause: installViaCli ran cp.spawnSync(bin, args, { shell: true }). With
+// shell:true Node does NOT quote the command, so cmd.exe receives the bare
+// binary path. The real code-insiders shim lives at
+//   C:\Users\<user>\AppData\Local\Programs\Microsoft VS Code Insiders\bin\code-insiders.cmd
+// which contains spaces, so cmd.exe split it at the first space and reported
+//   "'...\Microsoft' is not recognized as an internal or external command"
+// — surfaced to the user as "Failed to install Claude Chat". The old code
+// comment claimed shell:true AVOIDS the spaces problem; it is exactly backwards.
+//
+// Fix: shared/install-command.ts builds the spawnSync inputs. When a shell is
+// required (Windows .cmd/.bat), it emits a single, fully-quoted command line so
+// a spaced binary path survives cmd.exe parsing.
+//
+// This test exercises the REAL compiled module (out/shared/install-command.js)
+// with injected data — no VS Code, no spawning. It self-heals by recompiling
+// when the artifact is missing or stale.
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { execSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SRC  = path.join(ROOT, 'src', 'shared', 'install-command.ts');
+const OUT  = path.join(ROOT, 'out', 'shared', 'install-command.js');
+
+// ── Ensure the compiled module is present and fresh ──────────────────────────
+function ensureCompiled() {
+    const needsBuild =
+        !fs.existsSync(OUT) ||
+        !fs.existsSync(SRC) ||
+        fs.statSync(SRC).mtimeMs > fs.statSync(OUT).mtimeMs;
+    if (needsBuild) {
+        execSync(`node "${path.join(ROOT, 'esbuild.mjs')}"`, { cwd: ROOT, stdio: 'pipe' });
+    }
+}
+ensureCompiled();
+
+const mod = require(OUT);
+const { buildInstallCommand, shellQuote } = mod;
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try   { fn(); console.log(`  PASS ${name}`); passed++; }
+    catch (e) { console.error(`  FAIL ${name}\n       ${e.message}`); failed++; }
+}
+
+console.log('REG-117: corequisite-checker — install command quotes a spaced .cmd path (#592)');
+console.log('-'.repeat(70));
+
+const SPACED_CMD = 'C:\\Users\\jwpmi\\AppData\\Local\\Programs\\Microsoft VS Code Insiders\\bin\\code-insiders.cmd';
+const SPACED_VSIX = 'C:\\Users\\jwpmi\\Downloads\\My Extensions\\claude-chat.vsix';
+
+// ── The #592 regression itself ───────────────────────────────────────────────
+test('spaced .cmd on win32 -> command line wraps the binary in quotes', () => {
+    const r = buildInstallCommand(SPACED_CMD, SPACED_VSIX, 'win32');
+    assert.strictEqual(r.shell, true, 'a .cmd shim must run through a shell');
+    assert.ok(r.command.includes(`"${SPACED_CMD}"`),
+        `binary must be quoted so cmd.exe does not split it at the space — got: ${r.command}`);
+});
+
+test('spaced .cmd on win32 -> command line wraps the vsix path in quotes', () => {
+    const r = buildInstallCommand(SPACED_CMD, SPACED_VSIX, 'win32');
+    assert.ok(r.command.includes(`"${SPACED_VSIX}"`),
+        `vsix path must be quoted — got: ${r.command}`);
+});
+
+test('the spaced binary is NEVER emitted unquoted (the exact #592 failure)', () => {
+    const r = buildInstallCommand(SPACED_CMD, SPACED_VSIX, 'win32');
+    // The bug: the bare token "...\Microsoft VS Code Insiders\..." reaching the
+    // shell. Assert the unquoted path is not present as a free-standing token.
+    assert.ok(!r.command.includes(`${SPACED_CMD} `) && !r.command.endsWith(SPACED_CMD),
+        `binary path must not appear unquoted — got: ${r.command}`);
+});
+
+test('when shell is used the args array is empty (command carries the line)', () => {
+    const r = buildInstallCommand(SPACED_CMD, SPACED_VSIX, 'win32');
+    assert.deepStrictEqual(r.args, []);
+});
+
+test('--install-extension flag is present and left unquoted', () => {
+    const r = buildInstallCommand(SPACED_CMD, SPACED_VSIX, 'win32');
+    assert.ok(/(^|\s)--install-extension(\s)/.test(r.command),
+        `flag must be a bare token — got: ${r.command}`);
+});
+
+// ── Non-shell paths (bare exe / non-Windows) keep the argv form ──────────────
+test('non-.cmd binary on win32 -> no shell, argv form preserved', () => {
+    const r = buildInstallCommand('code-insiders', SPACED_VSIX, 'win32');
+    assert.strictEqual(r.shell, false);
+    assert.strictEqual(r.command, 'code-insiders');
+    assert.deepStrictEqual(r.args, ['--install-extension', SPACED_VSIX]);
+});
+
+test('non-Windows .cmd-looking name -> no shell (shell quoting is Windows-only)', () => {
+    const r = buildInstallCommand('/usr/bin/weird.cmd', '/tmp/a b.vsix', 'linux');
+    assert.strictEqual(r.shell, false);
+    assert.deepStrictEqual(r.args, ['--install-extension', '/tmp/a b.vsix']);
+});
+
+test('.bat shim is treated the same as .cmd', () => {
+    const r = buildInstallCommand('C:\\Program Files\\x\\code.bat', SPACED_VSIX, 'win32');
+    assert.strictEqual(r.shell, true);
+    assert.ok(r.command.includes('"C:\\Program Files\\x\\code.bat"'));
+});
+
+// ── shellQuote helper ────────────────────────────────────────────────────────
+test('shellQuote wraps a plain token in double quotes', () => {
+    assert.strictEqual(shellQuote('a b'), '"a b"');
+});
+
+test('shellQuote escapes embedded double quotes', () => {
+    assert.strictEqual(shellQuote('a"b'), '"a""b"');
+});
+
+console.log('-'.repeat(70));
+if (failed === 0) {
+    console.log(`✓ REG-117 passed (${passed} checks).\n`);
+    process.exit(0);
+}
+console.error(`✗ REG-117 FAILED (${failed} of ${passed + failed} checks failed).\n`);
+process.exit(1);

--- a/tests/unit/corequisite-checker.test.js
+++ b/tests/unit/corequisite-checker.test.js
@@ -55,8 +55,15 @@ test('source has Windows-safe CLI fallback for .cmd/.bat', () => {
     if (!fs.existsSync(src)) return;
     const text = fs.readFileSync(src, 'utf8');
     assert.ok(text.includes('spawnSync'));
-    assert.ok(text.includes('/\\.(cmd|bat)\\$/i'));
-    assert.ok(text.includes("process.env.ComSpec || 'cmd.exe'"));
+    // #592: the .cmd/.bat detection + quoting now lives in shared/install-command.ts;
+    // corequisite-checker delegates to buildInstallCommand for a quoted command line.
+    assert.ok(text.includes('buildInstallCommand'));
+    const shared = path.join(__dirname, '../../src/shared/install-command.ts');
+    if (fs.existsSync(shared)) {
+        const sharedText = fs.readFileSync(shared, 'utf8');
+        assert.ok(sharedText.includes('/\\.(cmd|bat)$/i'));
+        assert.ok(sharedText.includes('shellQuote'));
+    }
 });
 test('activate does not throw synchronously', () => {
     const ctx = { subscriptions: [] };


### PR DESCRIPTION
Lands the remaining stranded feature work onto main (7 commits, cherry-picked + conflicts resolved).

- **#605** Question status (purple pill, Questions banner/filter, per-row Answered)
- **issue-viewer state pill** traffic-light (open/in-progress/closed) — REG-112
- **#602** corequisite-checker no longer flags a just-installed extension as missing
- **#591** notify-server port-in-use → warning, not auto-filed APP_ERROR
- **#601** bg-health saveState retries + dedupes failure logging — REG-116
- **#592** quote spaced .cmd path on corequisite VSIX install — REG-117 (new shared install-command.ts)
- DiskCleanUp duplicate-images scan crash fix

Conflicts resolved: union-merged esbuild.mjs build blocks; kept both corequisite imports; took state-pill branch's coherent actions-cell. Regression: **132/132 green**.

Squash-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)