### PR TITLE
feat: land daily-audit work — #548 auto-file, #555/#556 path fixes, #557 bg-health, doc-catalog cleanup

### DIFF
--- a/src/features/background-health-runner.ts
+++ b/src/features/background-health-runner.ts
@@ -171,8 +171,7 @@ function addBug(bug: Omit<HealthBug, 'detectedAt' | 'fixed'>): void {
         _state.bugs.push({ ...bug, detectedAt: new Date().toISOString(), fixed: false });
     }
     // Mirror to error log so the Error Log panel shows it without a separate viewer
-    // No caught exception here — stack stored in bug.stack; pass '' per logError contract
-    logError(`[bg-health] ${bug.title}`, '', `${bug.detail || bug.id}${bug.stack ? '\n' + bug.stack : ''}`);
+    logError(`[bg-health] ${bug.title}`, '', FEATURE);
 }
 
 function clearBug(id: string): void {

--- a/src/features/daily-audit/checks/changelog.ts
+++ b/src/features/daily-audit/checks/changelog.ts
@@ -17,21 +17,21 @@ export function runChangelogCheck(projects: ProjectEntry[]): AuditCheck {
     const t0  = Date.now();
     const now = Date.now();
 
-    const missing: string[] = [];
-    const stale:   string[] = [];
-    const fresh:   string[] = [];
+    const missing: ProjectEntry[] = [];
+    const stale:   ProjectEntry[] = [];
+    const fresh:   ProjectEntry[] = [];
 
     for (const p of projects) {
         if (!fs.existsSync(p.path)) { continue; }
         const clPath = path.join(p.path, 'CHANGELOG.md');
         if (!fs.existsSync(clPath)) {
-            missing.push(p.name);
+            missing.push(p);
             continue;
         }
         const mtime   = fs.statSync(clPath).mtimeMs;
         const ageDays = (now - mtime) / (1000 * 60 * 60 * 24);
-        if (ageDays > STALE_DAYS) { stale.push(p.name); }
-        else                       { fresh.push(p.name); }
+        if (ageDays > STALE_DAYS) { stale.push(p); }
+        else                       { fresh.push(p); }
     }
 
     let status: AuditCheck['status'];
@@ -40,13 +40,13 @@ export function runChangelogCheck(projects: ProjectEntry[]): AuditCheck {
 
     if (missing.length > 0) {
         status  = 'red';
-        summary = `No CHANGELOG in: ${missing.join(', ')}`;
-        detail  = `${missing.length} project(s) have no CHANGELOG.md: ${missing.join(', ')}\n` +
-                  (stale.length > 0 ? `${stale.length} project(s) have changelogs not updated in ${STALE_DAYS}+ days: ${stale.join(', ')}` : '');
+        summary = `No CHANGELOG in: ${missing.map(p => p.name).join(', ')}`;
+        detail  = `${missing.length} project(s) have no CHANGELOG.md: ${missing.map(p => p.name).join(', ')}\n` +
+                  (stale.length > 0 ? `${stale.length} project(s) have changelogs not updated in ${STALE_DAYS}+ days: ${stale.map(p => p.name).join(', ')}` : '');
     } else if (stale.length > 0) {
         status  = 'yellow';
-        summary = `${stale.length} changelog${stale.length > 1 ? 's' : ''} not updated in ${STALE_DAYS}+ days — ${stale.join(', ')}`;
-        detail  = `These projects have changelogs that haven't been touched in over ${STALE_DAYS} days:\n${stale.join(', ')}`;
+        summary = `${stale.length} changelog${stale.length > 1 ? 's' : ''} not updated in ${STALE_DAYS}+ days — ${stale.map(p => p.name).join(', ')}`;
+        detail  = `These projects have changelogs that haven't been touched in over ${STALE_DAYS} days:\n${stale.map(p => p.name).join(', ')}`;
     } else {
         status  = 'green';
         summary = `All ${fresh.length} changelogs up to date`;
@@ -60,8 +60,8 @@ export function runChangelogCheck(projects: ProjectEntry[]): AuditCheck {
         status,
         summary,
         detail,
-        affectedProjects: [...missing, ...stale],
-        affectedFiles:    [...missing, ...stale].map(n => path.join(n, 'CHANGELOG.md')),
+        affectedProjects: [...missing, ...stale].map(p => p.name),
+        affectedFiles:    [...missing, ...stale].map(p => path.join(p.path, 'CHANGELOG.md')),
         action:           'cvs.marketplace.scan',
         actionLabel:      missing.length > 0 ? 'Auto-Fix' : 'Review',
         ranAt:            new Date().toISOString(),

--- a/src/features/daily-audit/checks/marketplace.ts
+++ b/src/features/daily-audit/checks/marketplace.ts
@@ -14,15 +14,16 @@ interface ProjectEntry { name: string; path: string; type: string; }
 const OPEN_SOURCE_LICENSES = ['MIT', 'ISC', 'Apache-2.0', 'GPL-2.0', 'GPL-3.0', 'BSD-2-Clause', 'BSD-3-Clause'];
 
 interface ProjectResult {
-    name:    string;
-    score:   number;
-    missing: string[];
+    name:     string;
+    projPath: string;
+    score:    number;
+    missing:  string[];
 }
 
 function checkOne(project: ProjectEntry): ProjectResult {
     const missing: string[] = [];
     const isExtension = project.type === 'vscode-extension';
-    if (!fs.existsSync(project.path)) { return { name: project.name, score: 0, missing: ['project folder not found'] }; }
+    if (!fs.existsSync(project.path)) { return { name: project.name, projPath: project.path, score: 0, missing: ['project folder not found'] }; }
 
     if (!fs.existsSync(path.join(project.path, 'LICENSE')) &&
         !fs.existsSync(path.join(project.path, 'LICENSE.txt'))) { missing.push('LICENSE'); }
@@ -51,7 +52,22 @@ function checkOne(project: ProjectEntry): ProjectResult {
     const errors   = missing.filter(m => !m.includes('icon') && !m.includes('CHANGELOG')).length;
     const warnings = missing.filter(m =>  m.includes('icon') ||  m.includes('CHANGELOG')).length;
     const score    = Math.max(0, 100 - errors * 20 - warnings * 8);
-    return { name: project.name, score, missing };
+    return { name: project.name, projPath: project.path, score, missing };
+}
+
+function missingToFiles(r: ProjectResult): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const m of r.missing) {
+        let file: string;
+        if (m.startsWith('package.json')) { file = path.join(r.projPath, 'package.json'); }
+        else if (m === 'LICENSE' || m === 'LICENSE.txt') { file = path.join(r.projPath, 'LICENSE'); }
+        else if (m === 'CHANGELOG.md') { file = path.join(r.projPath, 'CHANGELOG.md'); }
+        else if (m === 'icon.png')     { file = path.join(r.projPath, 'icon.png'); }
+        else { continue; }
+        if (!seen.has(file)) { seen.add(file); out.push(file); }
+    }
+    return out;
 }
 
 export function runMarketplaceCheck(projects: ProjectEntry[]): AuditCheck {
@@ -89,7 +105,7 @@ export function runMarketplaceCheck(projects: ProjectEntry[]): AuditCheck {
         summary,
         detail,
         affectedProjects: [...red, ...yellow].map(r => r.name),
-        affectedFiles:    [...red, ...yellow].flatMap(r => r.missing),
+        affectedFiles:    [...red, ...yellow].flatMap(r => missingToFiles(r)),
         action:           'cvs.marketplace.scan',
         actionLabel:      red.length > 0 ? 'Fix Now' : yellow.length > 0 ? 'Review' : 'Open',
         ranAt:            new Date().toISOString(),

--- a/src/features/daily-audit/checks/readme-quality.ts
+++ b/src/features/daily-audit/checks/readme-quality.ts
@@ -11,14 +11,14 @@ import type { AuditCheck } from '../../../shared/audit-schema';
 
 interface ProjectEntry { name: string; path: string; }
 
-interface ProjectResult { name: string; status: 'missing' | 'stub' | 'ok'; lines: number; }
+interface ProjectResult { name: string; path: string; status: 'missing' | 'stub' | 'ok'; lines: number; }
 
 function checkOne(project: ProjectEntry): ProjectResult {
     const readmePath = path.join(project.path, 'README.md');
-    if (!fs.existsSync(readmePath)) { return { name: project.name, status: 'missing', lines: 0 }; }
+    if (!fs.existsSync(readmePath)) { return { name: project.name, path: project.path, status: 'missing', lines: 0 }; }
     const content = fs.readFileSync(readmePath, 'utf8');
     const lines   = content.split('\n').length;
-    return { name: project.name, status: lines < 20 ? 'stub' : 'ok', lines };
+    return { name: project.name, path: project.path, status: lines < 20 ? 'stub' : 'ok', lines };
 }
 
 export function runReadmeQualityCheck(projects: ProjectEntry[]): AuditCheck {
@@ -56,7 +56,7 @@ export function runReadmeQualityCheck(projects: ProjectEntry[]): AuditCheck {
         summary,
         detail,
         affectedProjects: [...missing, ...stubs].map(r => r.name),
-        affectedFiles:    [...missing].map(r => path.join(r.name, 'README.md')),
+        affectedFiles:    [...missing, ...stubs].map(r => path.join(r.path, 'README.md')),
         action:           'cvs.readme.scan',
         actionLabel:      missing.length > 0 ? 'Generate Now' : stubs.length > 0 ? 'Fix Now' : 'Scan',
         ranAt:            new Date().toISOString(),

--- a/src/features/daily-audit/index.ts
+++ b/src/features/daily-audit/index.ts
@@ -12,8 +12,55 @@ import { log } from '../../shared/output-channel';
 import { showInteractiveResultWebview } from '../../shared/show-interactive-result-webview';
 import { runDailyAudit } from './runner';
 import { AUDIT_REPORT_PATH } from '../../shared/audit-schema';
+import { fileDailyAuditCheckAsIssue } from '../../shared/github-issue-filer';
 
 const FEATURE = 'daily-audit';
+
+type IssueLink = { issueUrl: string; issueNumber: number };
+
+function esc(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildAuditOutputHtml(
+    result: Awaited<ReturnType<typeof runDailyAudit>>,
+    issueMap: Map<string, IssueLink>
+): string {
+    const r      = result.report.summary;
+    const checks = result.report.checks;
+    const runAt  = new Date(result.report.generatedAt).toLocaleTimeString();
+    let html = `<pre style="font-family:var(--vscode-editor-font-family);white-space:pre-wrap;margin:0">`;
+    html += `Projects audited (${result.projectNames.length}): ${esc(result.projectNames.join(', '))}\n`;
+    html += `\n=== Daily Audit Results ===\n`;
+    html += `Fresh scan — ran at ${runAt}\n`;
+    html += `Scanned ${checks.length} checks in ${result.report.durationMs}ms\n`;
+    html += `Summary: ${r.red} red, ${r.yellow} yellow, ${r.green} green, ${r.grey} grey\n\n---\n`;
+    for (const check of checks) {
+        const icon = check.status === 'green' ? '✅' : check.status === 'red' ? '❌' : check.status === 'yellow' ? '⚠️' : '▫️';
+        html += `${icon} ${esc(check.title)} [${esc(check.category)}] — ${esc(check.summary)}`;
+        const link = issueMap.get(check.checkId);
+        if (link) {
+            html += ` <a href="#" data-issue-url="${esc(link.issueUrl)}" style="color:var(--vscode-textLink-foreground);text-decoration:none" title="View GitHub issue #${link.issueNumber}">#${link.issueNumber}</a>`;
+        }
+        html += '\n';
+        if (check.detail && check.status !== 'green') {
+            html += `   Detail: ${esc(check.detail.slice(0, 300))}\n`;
+        }
+        if (check.affectedProjects?.length) {
+            html += `   Affected: ${esc(check.affectedProjects.slice(0, 6).join(', '))}\n`;
+        }
+        if (check.affectedFiles?.length) {
+            html += `   Files: ${esc(check.affectedFiles.slice(0, 3).join(', '))}\n`;
+        }
+        if (check.actionLabel && check.action && check.status !== 'green') {
+            html += `   Fix: ${esc(check.actionLabel)} → ${esc(check.action)}\n`;
+        }
+        html += '\n';
+    }
+    html += `---\nAudit complete — ${r.red} red, ${r.yellow} yellow, ${r.green} green`;
+    html += `</pre>`;
+    return html;
+}
 
 function buildMarkdownReport(result: Awaited<ReturnType<typeof runDailyAudit>>): string {
     const r = result.report.summary;
@@ -205,6 +252,37 @@ export function activate(context: vscode.ExtensionContext): void {
                             vscode.commands.executeCommand('cvs.audit.runDaily');
                         },
                     });
+
+                    // Fire-and-forget: auto-file issues for red/yellow checks, then
+                    // update the panel with clickable issue links once filing is done.
+                    if (result.written) {
+                        const _capturedResult = result;
+                        const _capturedTitle  = title;
+                        const _capturedFailed = failed;
+                        void (async () => {
+                            const failures = _capturedResult.report.checks.filter(c => c.status === 'red' || c.status === 'yellow');
+                            if (!failures.length) { return; }
+                            const issueMap = new Map<string, IssueLink>();
+                            for (const check of failures) {
+                                try {
+                                    const r = await fileDailyAuditCheckAsIssue(check);
+                                    if (r.ok && r.issueUrl && r.issueNumber != null) {
+                                        issueMap.set(check.checkId, { issueUrl: r.issueUrl, issueNumber: r.issueNumber });
+                                    }
+                                } catch { /* best-effort */ }
+                            }
+                            if (!issueMap.size) { return; }
+                            showInteractiveResultWebview({
+                                title: _capturedTitle,
+                                action: 'Run Daily Health Check',
+                                output: buildAuditOutputHtml(_capturedResult, issueMap),
+                                durationMs: _capturedResult.report.durationMs,
+                                failed: _capturedFailed,
+                                viewType: 'dailyAuditResults',
+                                onRerun: () => { vscode.commands.executeCommand('cvs.audit.runDaily'); },
+                            });
+                        })();
+                    }
 
                     // Also log to output channel
                     if (result.written) {

--- a/src/features/doc-catalog/commands.ts
+++ b/src/features/doc-catalog/commands.ts
@@ -432,7 +432,7 @@ export async function openCatalog(forceRebuild = false): Promise<void> {
     const cards = await buildCatalog(forceRebuild);
     if (!cards?.length) { vscode.window.showWarningMessage('No docs found to catalog.'); return; }
     queueCatalogInit(cards, projectInfos, registry?.projects ?? []);
-    const html = buildCatalogHtml(cards, projectInfos, new Date().toLocaleString(), registry?.projects ?? []);
+    const html = buildCatalogHtml();
     const hadPanel = Boolean(_catalogPanel);
     if (_catalogPanel) {
         _catalogPanel.webview.html = html;
@@ -955,7 +955,7 @@ export function deserializeCatalogPanel(panel: vscode.WebviewPanel): void {
         _pendingInitCards           = cards;
         _pendingInitProjectInfos    = projectInfos;
         _pendingInitRegistryEntries = registry?.projects ?? [];
-        _catalogPanel!.webview.html = buildCatalogHtml(cards, projectInfos, new Date().toLocaleString(), registry?.projects ?? []);
+        _catalogPanel!.webview.html = buildCatalogHtml();
         trySendPendingCatalogInit(_catalogPanel!);
     });
     _catalogPanel.onDidDispose(() => { _catalogPanel = undefined; });

--- a/src/features/doc-catalog/html.ts
+++ b/src/features/doc-catalog/html.ts
@@ -161,16 +161,6 @@ export function buildCatalogInitPayload(
     };
 }
 
-// ─── Legacy shim — kept so callers don't break during transition ──────────────
-// TODO: remove once commands.ts is updated to use buildCatalogInitPayload
-
-export function buildCatalogHtml(
-    cards: CatalogCard[],
-    projectInfos: ProjectInfo[] = [],
-    builtAt = '',
-    registryEntries: Array<{ name: string; path: string; type: string; description: string }> = []
-): string {
-    // Return the shell — the panel will postMessage 'init' with the card data
-    // This is called by commands.ts; it should follow up with postMessage immediately.
+export function buildCatalogHtml(): string {
     return getCatalogShellHtml();
 }

--- a/src/shared/github-issue-filer.ts
+++ b/src/shared/github-issue-filer.ts
@@ -27,6 +27,7 @@
 import * as vscode from 'vscode';
 import * as https from 'https';
 import type { ErrorEntry } from './error-log-adapter';
+import type { AuditCheck } from './audit-schema';
 
 const REPO_OWNER = 'CieloVistaSoftware';
 const REPO_NAME  = 'cielovista-tools';
@@ -467,6 +468,73 @@ export async function fetchAutoFiledIssueMap(): Promise<Map<string, { number: nu
         req.on('error', () => resolve(null));
         req.end();
     });
+}
+
+/**
+ * File a GitHub issue for a failing daily-audit check.
+ * Title is deterministic — `[daily-audit] {check.title}` — so the dedup
+ * check finds it on subsequent runs and adds a comment instead of a duplicate.
+ */
+export async function fileDailyAuditCheckAsIssue(check: AuditCheck): Promise<FileIssueResult> {
+    const token = await getGithubToken();
+    const title = `[daily-audit] ${check.title}`;
+    const lines: string[] = [
+        '## Daily Audit Failure',
+        '',
+        `**Check ID:** \`${check.checkId}\``,
+        `**Category:** ${check.category}`,
+        `**Status:** ${check.status}`,
+        `**Ran at:** ${check.ranAt}`,
+        '',
+        '### Summary',
+        check.summary,
+    ];
+    if (check.detail) {
+        lines.push('', '### Detail', check.detail);
+    }
+    if (check.affectedProjects?.length) {
+        lines.push('', `**Affected projects:** ${check.affectedProjects.join(', ')}`);
+    }
+    if (check.affectedFiles?.length) {
+        lines.push('', '**Affected files:**', '```', ...check.affectedFiles.slice(0, 20), '```');
+    }
+    if (check.actionLabel && check.action) {
+        lines.push('', `**Fix:** ${check.actionLabel} → \`${check.action}\``);
+    }
+    lines.push('', '---', '*Filed from CVT Daily Audit on ' + new Date().toISOString() + '*');
+
+    const body   = lines.join('\n');
+    const labels = withRequiredProjectLabel(['auto-filed', 'daily-audit', 'type:bug', `area:${check.category.toLowerCase().replace(/\s+/g, '-')}`]);
+
+    if (!token) {
+        const copied = await copyIssueToClipboard(title, body);
+        return { ok: false, error: 'GitHub authentication was canceled or failed.', copiedToClipboard: copied };
+    }
+
+    const existing = await findOpenAutoFiledIssue(token, title);
+    if (existing) {
+        const comment = [
+            `Recurrence detected at ${new Date().toISOString()}.`,
+            '',
+            `**Status:** ${check.status}`,
+            `**Summary:** ${check.summary}`,
+            '',
+            '_Posted via dedup — title matched this open auto-filed issue._',
+        ].join('\n');
+        const ok = await postIssueComment(token, existing.number, comment);
+        return ok
+            ? { ok: true, issueUrl: existing.html_url, issueNumber: existing.number }
+            : { ok: false, error: `Matched issue #${existing.number} but comment failed to post.` };
+    }
+
+    try {
+        const res = await postIssue(token, title, body, labels);
+        return { ok: true, issueUrl: res.html_url, issueNumber: res.number };
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const copied = await copyIssueToClipboard(title, body);
+        return { ok: false, error: msg, copiedToClipboard: copied };
+    }
 }
 
 export interface FrontmatterIssueInput {

--- a/src/shared/show-interactive-result-webview.ts
+++ b/src/shared/show-interactive-result-webview.ts
@@ -111,6 +111,8 @@ export function showInteractiveResultWebview(opts: InteractiveResultOptions) {
         active.onRerun();
       } else if (msg.type === 'openLog' && active.onOpenLog) {
         active.onOpenLog();
+      } else if (msg.type === 'openUrl' && typeof msg.url === 'string') {
+        void vscode.env.openExternal(vscode.Uri.parse(msg.url));
       } else if (msg.type === 'close') {
         panel.dispose();
       }
@@ -203,6 +205,10 @@ export function showInteractiveResultWebview(opts: InteractiveResultOptions) {
               const btn = document.getElementById('rerunBtn');
               if (btn) { btn.disabled = true; btn.textContent = 'Running\u2026'; }
             }
+          });
+          document.addEventListener('click', function(e) {
+            var el = e.target.closest('[data-issue-url]');
+            if (el) { e.preventDefault(); vscode.postMessage({ type: 'openUrl', url: el.dataset.issueUrl }); }
           });
         </script>
       </body>


### PR DESCRIPTION
Lands the still-unique work from inspiring-kapitsa onto main (5 commits).

- **#548** daily-audit auto-files issues + clickable links (new shared github-issue-filer.ts)
- **#555** daily-audit checks use full project paths in affectedFiles
- **#556** marketplace check produces absolute paths
- **#557** bg-health logError passes FEATURE as context, not bug detail
- doc-catalog: remove dead params from buildCatalogHtml shim

Skipped as superseded by already-landed work: #542/#543 doc-audit panel (main has a newer version), #554 RAM display (already in main).

Regression: **132/132 green**. Squash-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)