### PR TITLE
fix #615: launch MCP server via VS Code bundled Node (stop 0xC0000142 startup crashes)

### DIFF
--- a/docs/_today/CURRENT-STATUS.md
+++ b/docs/_today/CURRENT-STATUS.md
@@ -2,10 +2,10 @@
 
 ## 🅿️ PARKING LOT
 
-**Task:** —  clean slate
-**Files touched:** none
-**Last action:** PR #521 squash-merged into main 2026-05-25; `release/session-fixes-2026-05-25` deleted; branch protection restored (1 required review); local main synced
-**Next step:** Pick next open GitHub issue
+**Task:** #615 — MCP server crashes on startup (0xC0000142 STATUS_DLL_INIT_FAILED) on Windows
+**Files touched:** `src/features/mcp-server-status.ts`, `tests/unit/mcp-server-status.test.js`, `tests/regression/REG-116-mcp-bundled-node-launch.test.js`, `data/claude-job-status.json`
+**Last action:** Launch MCP via VS Code bundled Node (`process.execPath` + `ELECTRON_RUN_AS_NODE=1`) instead of PATH `node`; added `windowsHide: true`; recorded resolved node path in crash diagnostics. Compile clean, all 133 regression tests green (built `mcp-server/dist` first — worktree gap).
+**Next step:** Commit + open PR for #615; then pick next open issue
 **Open questions:** None
 
 ---

--- a/scripts/run-regression-tests.js
+++ b/scripts/run-regression-tests.js
@@ -151,42 +151,42 @@ function ensureOutBuilt() {
   if (rebuilt) { console.log(''); }
 }
 
-// ── Main ──────────────────────────────────────────────────────────────────────
+// ── Preflight: ensure mcp-server/dist is built ────────────────────────────────
+// Like out/, mcp-server/dist is not shared across git worktrees. REG-074 probes
+// mcp-server/dist/http.js, so build it on first run with the same tsc the suite
+// uses for REG-003 — otherwise a fresh worktree fails on a missing build artifact
+// instead of a real test failure.
+function ensureMcpServerBuilt() {
+  const mcpRoot   = path.join(ROOT, 'mcp-server');
+  const mcpMarker = path.join(mcpRoot, 'dist', 'http.js');
+  if (!fs.existsSync(path.join(mcpRoot, 'tsconfig.json'))) { return; }
+  if (fs.existsSync(mcpMarker)) { return; }
 
-// ── Preflight: ensure out/ is built ──────────────────────────────────────────
-// Git worktrees have no shared out/ — auto-build on first run so tests that
-// probe out/extension.js and out/catalog.html don't fail with a missing-file
-// error instead of a real test failure.
-function ensureOutBuilt() {
-  const outBundle = path.join(ROOT, 'out', 'extension.js');
-  const outHtml   = path.join(ROOT, 'out', 'catalog.html');
-  let rebuilt = false;
-
-  if (!fs.existsSync(outBundle)) {
-    console.log('  ⚙  out/extension.js missing — running esbuild.mjs...');
-    try {
-      execSync(`node "${path.join(ROOT, 'esbuild.mjs')}"`, { cwd: ROOT, stdio: 'inherit' });
-      rebuilt = true;
-    } catch {
-      console.error('  ✗ esbuild.mjs failed — some tests may fail');
-    }
+  const tscBin = [
+    path.join(ROOT, 'node_modules', '.bin', 'tsc'),
+    path.join(ROOT, '..', '..', '..', 'node_modules', '.bin', 'tsc'),
+  ].find(p => fs.existsSync(p));
+  if (!tscBin) {
+    console.error('  ✗ tsc not found — cannot build mcp-server/dist (REG-074 will fail)');
+    return;
   }
 
-  if (!fs.existsSync(outHtml)) {
-    console.log('  ⚙  out/catalog.html missing — running copy-commandhelp.js...');
-    try {
-      execSync(`node "${path.join(ROOT, 'scripts', 'copy-commandhelp.js')}"`, { cwd: ROOT, stdio: 'inherit' });
-      rebuilt = true;
-    } catch {
-      console.error('  ✗ copy-commandhelp.js failed — REG-012 will fail');
-    }
+  // On Windows the .bin entry is a .cmd shim; execSync runs through cmd.exe.
+  const tscExe = process.platform === 'win32' ? `${tscBin}.cmd` : tscBin;
+  console.log('  ⚙  mcp-server/dist/http.js missing — building mcp-server...');
+  try {
+    execSync(`"${tscExe}" -p "${mcpRoot}"`, { cwd: ROOT, stdio: 'inherit' });
+    console.log('');
+  } catch {
+    console.error('  ✗ mcp-server build failed — REG-074 will fail');
   }
-
-  if (rebuilt) { console.log(''); }
 }
+
+// ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main() {
   ensureOutBuilt();
+  ensureMcpServerBuilt();
   console.log('\nCieloVista Tools — Regression Test Suite');
   console.log('─'.repeat(50));
   console.log('  Launching all tests concurrently...\n');

--- a/src/features/mcp-server-status.ts
+++ b/src/features/mcp-server-status.ts
@@ -266,6 +266,37 @@ function buildMcpLaunchConfig(attemptNumber: number): { args: string[]; env: Nod
     return { args, env, traceMode };
 }
 
+/**
+ * Resolves the Node binary used to launch the MCP server (issue #615).
+ *
+ * Previously the server was launched with spawn('node', …), which delegates
+ * binary resolution to whatever `node.exe` happens to be first on the system
+ * PATH. On Windows that binary can be the wrong ABI, an antivirus-wrapped
+ * shim, or a launcher whose DLL import table fails to initialize — surfacing
+ * as STATUS_DLL_INIT_FAILED (0xC0000142) with empty stdout/stderr, before any
+ * application code runs. It is intermittent because the loader failure is a
+ * race in the OS/AV layer, not in our code.
+ *
+ * VS Code always ships its own Node runtime as the Electron host binary
+ * (process.execPath). Re-invoking that binary with ELECTRON_RUN_AS_NODE=1
+ * makes it behave as a plain Node interpreter with an ABI guaranteed to match
+ * the host. This removes the PATH dependency entirely — no external node.exe
+ * to mis-resolve or fail to load.
+ *
+ * If process.execPath is somehow unavailable we fall back to 'node' so the
+ * server can still start in non-Electron / test contexts.
+ */
+function resolveNodeLauncher(env: NodeJS.ProcessEnv): { command: string; env: NodeJS.ProcessEnv } {
+    const electronHost = process.execPath;
+    if (electronHost) {
+        return {
+            command: electronHost,
+            env: { ...env, ELECTRON_RUN_AS_NODE: '1' },
+        };
+    }
+    return { command: 'node', env };
+}
+
 function writeMcpCrashDiagnostics(params: {
     attemptNumber: number;
     reason: string;
@@ -273,6 +304,7 @@ function writeMcpCrashDiagnostics(params: {
     args: string[];
     stdoutTail: string;
     stderrTail: string;
+    nodePath?: string;
 }): string | null {
     try {
         fs.mkdirSync(MCP_DIAG_DIR, { recursive: true });
@@ -286,6 +318,7 @@ function writeMcpCrashDiagnostics(params: {
             `reason=${params.reason}`,
             `attempt=${params.attemptNumber}`,
             `traceMode=${params.traceMode}`,
+            `nodePath=${params.nodePath ?? '(default)'}`,
             `nodeArgs=${JSON.stringify(params.args)}`,
             '',
             '--- stderr tail ---',
@@ -343,9 +376,16 @@ function runMcpProcess(): void {
     }
     log(FEATURE, `Starting MCP process attempt ${attemptNumber}`);
 
-    const child = spawn('node', launch.args, {
-        env: launch.env,
+    // #615 — launch via VS Code's bundled Node (process.execPath) rather than a
+    // PATH-resolved node.exe that can fail DLL-init (0xC0000142) on Windows.
+    const { command, env: launchEnv } = resolveNodeLauncher(launch.env);
+
+    const child = spawn(command, launch.args, {
+        env: launchEnv,
         stdio: ['pipe', 'pipe', 'pipe'],
+        // Avoid allocating a console/desktop-heap window per spawn; rapid
+        // restarts of console subsystem processes are a known 0xC0000142 trigger.
+        windowsHide: true,
     });
     mcpProcess = child;
 
@@ -392,6 +432,7 @@ function runMcpProcess(): void {
             args: launch.args,
             stdoutTail,
             stderrTail,
+            nodePath: command,
         });
         if (diagPath) {
             terminalWriteLine(`[CVT MCP] Crash diagnostics written: ${diagPath}`);
@@ -435,6 +476,7 @@ function runMcpProcess(): void {
             args: launch.args,
             stdoutTail,
             stderrTail,
+            nodePath: command,
         });
         if (diagPath) {
             terminalWriteLine(`[CVT MCP] Crash diagnostics written: ${diagPath}`);
@@ -485,6 +527,7 @@ export const _test = {
     onMcpServerStatusChange,
     notifyListeners,
     buildMcpLaunchConfig,
+    resolveNodeLauncher,
     writeMcpCrashDiagnostics,
     trimTail,
     appendTail,

--- a/tests/regression/REG-116-mcp-bundled-node-launch.test.js
+++ b/tests/regression/REG-116-mcp-bundled-node-launch.test.js
@@ -1,0 +1,117 @@
+/**
+ * REG-116-mcp-bundled-node-launch.test.js
+ *
+ * Regression test for #615 — MCP server crashes on startup with
+ * STATUS_DLL_INIT_FAILED (0xC0000142) on Windows.
+ *
+ * Root cause: the supervisor spawned the server with spawn('node', …), which
+ * delegates binary resolution to the system PATH. On Windows the resolved
+ * node.exe can be the wrong ABI or an antivirus-wrapped shim whose DLL import
+ * table fails to initialize, crashing before any application code runs (empty
+ * stdout/stderr, OS-level NTSTATUS exit code), intermittently.
+ *
+ * The fix: launch via VS Code's own bundled Node — process.execPath with
+ * ELECTRON_RUN_AS_NODE=1 — removing the PATH dependency and guaranteeing a
+ * matching ABI. windowsHide is also set to avoid console/desktop-heap pressure
+ * during rapid restarts (a known 0xC0000142 trigger).
+ *
+ * Checks (source-level):
+ *   1. resolveNodeLauncher() exists and is the spawn command source
+ *   2. The launcher prefers process.execPath
+ *   3. ELECTRON_RUN_AS_NODE=1 is set on the launch env
+ *   4. spawn() no longer hardcodes the literal 'node' binary
+ *   5. spawn() passes windowsHide: true
+ *   6. resolveNodeLauncher is exported on _test for unit testability
+ */
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const ROOT   = path.resolve(__dirname, '..', '..');
+const MCP_TS = path.join(ROOT, 'src', 'features', 'mcp-server-status.ts');
+
+let failed = 0;
+const fail = (msg) => { console.error('FAIL: ' + msg); failed++; };
+const ok   = (msg) => { console.log('PASS: ' + msg); };
+
+if (!fs.existsSync(MCP_TS)) {
+    console.error('FATAL: mcp-server-status.ts not found at ' + MCP_TS);
+    process.exit(1);
+}
+
+const src = fs.readFileSync(MCP_TS, 'utf8');
+
+// ─── Check 1: resolveNodeLauncher exists ─────────────────────────────────────
+
+(function checkLauncherDefined() {
+    if (!/function\s+resolveNodeLauncher\s*\(/.test(src)) {
+        fail('resolveNodeLauncher() not found — node binary resolution is not centralized');
+        return;
+    }
+    ok('resolveNodeLauncher() is defined');
+})();
+
+// ─── Check 2: prefers process.execPath ───────────────────────────────────────
+
+(function checkUsesExecPath() {
+    if (!/process\.execPath/.test(src)) {
+        fail('launcher does not reference process.execPath — still depends on a PATH-resolved node.exe (#615)');
+        return;
+    }
+    ok('launcher prefers process.execPath (VS Code bundled Node)');
+})();
+
+// ─── Check 3: ELECTRON_RUN_AS_NODE is set ────────────────────────────────────
+
+(function checkElectronRunAsNode() {
+    if (!/ELECTRON_RUN_AS_NODE\s*:\s*['"]1['"]/.test(src)) {
+        fail('ELECTRON_RUN_AS_NODE=1 is not set — the Electron host binary will not run as a plain Node interpreter');
+        return;
+    }
+    ok('ELECTRON_RUN_AS_NODE=1 is set on the launch env');
+})();
+
+// ─── Check 4: spawn uses the resolved launcher command ───────────────────────
+
+(function checkSpawnUsesResolvedCommand() {
+    // The live spawn must use the resolved command variable, not a hardcoded
+    // literal. (We assert the positive form so the historical 'node' string in
+    // the explanatory doc comment doesn't produce a false negative.)
+    if (!/spawn\(\s*command\s*,/.test(src)) {
+        fail('spawn() does not use the resolved launcher command — PATH-resolved node.exe remains the failure source (#615)');
+        return;
+    }
+    ok('spawn() uses the resolved launcher command (not a hardcoded binary)');
+})();
+
+// ─── Check 5: windowsHide is set on spawn ────────────────────────────────────
+
+(function checkWindowsHide() {
+    if (!/windowsHide\s*:\s*true/.test(src)) {
+        fail('spawn() does not pass windowsHide: true — rapid console-subsystem spawns can trigger 0xC0000142');
+        return;
+    }
+    ok('spawn() passes windowsHide: true');
+})();
+
+// ─── Check 6: resolveNodeLauncher exported on _test ──────────────────────────
+
+(function checkTestExport() {
+    if (!/resolveNodeLauncher,/.test(src)) {
+        fail('resolveNodeLauncher is not exported on _test — unit tests cannot verify launcher behavior');
+        return;
+    }
+    ok('resolveNodeLauncher is exported on _test for testability');
+})();
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+console.log('');
+if (failed === 0) {
+    console.log('REG-116 PASSED — MCP server launches via VS Code bundled Node (#615)');
+    process.exit(0);
+} else {
+    console.error('REG-116 FAILED — ' + failed + ' check' + (failed > 1 ? 's' : '') + ' failed');
+    process.exit(1);
+}

--- a/tests/unit/mcp-server-status.test.js
+++ b/tests/unit/mcp-server-status.test.js
@@ -81,6 +81,36 @@ test('launch config: trace flags and NODE_DEBUG at escalation attempt', () => {
     assert.ok(String(cfg.env.NODE_DEBUG || '').includes('module,http,net,tls'));
 });
 
+test('resolveNodeLauncher: uses VS Code host binary with ELECTRON_RUN_AS_NODE (#615)', () => {
+    const baseEnv = { PATH: 'whatever' };
+    const launcher = testApi.resolveNodeLauncher(baseEnv);
+
+    // When process.execPath is available (always true under node), the launcher
+    // must use it and flip ELECTRON_RUN_AS_NODE so it runs as a plain Node.
+    assert.strictEqual(launcher.command, process.execPath);
+    assert.strictEqual(launcher.env.ELECTRON_RUN_AS_NODE, '1');
+    // Existing env must be preserved, not clobbered.
+    assert.strictEqual(launcher.env.PATH, 'whatever');
+    // Must not mutate the caller's env object.
+    assert.strictEqual(baseEnv.ELECTRON_RUN_AS_NODE, undefined);
+});
+
+test('writeMcpCrashDiagnostics records the resolved node path (#615)', () => {
+    const filePath = testApi.writeMcpCrashDiagnostics({
+        attemptNumber: 2,
+        reason: 'process exited with code 3221225794',
+        traceMode: false,
+        args: ['index.js'],
+        stdoutTail: '',
+        stderrTail: '',
+        nodePath: 'C:/path/to/Code.exe',
+    });
+    assert.ok(filePath, 'expected a diagnostics file path');
+    const body = fs.readFileSync(filePath, 'utf8');
+    assert.ok(body.includes('nodePath=C:/path/to/Code.exe'), 'expected nodePath line in diagnostics');
+    fs.unlinkSync(filePath);
+});
+
 test('trimTail keeps only the latest max chars', () => {
     const max = testApi.DIAG_TAIL_MAX_CHARS;
     const source = 'a'.repeat(max + 100);


### PR DESCRIPTION
## Issue
Closes #615 — CVT MCP server crashes on startup with `0xC0000142` (STATUS_DLL_INIT_FAILED) on Windows, churning the supervisor's 10-attempt retry loop. Empty stdout/stderr ⇒ the crash is at OS/DLL init, before any application code runs; intermittent ⇒ a loader/AV race, not our code.

## Root cause
`mcp-server-status.ts` spawned the server with `spawn('node', …)`, delegating binary resolution to the system **PATH**. The resolved `node.exe` can be the wrong ABI or an antivirus-wrapped shim whose DLL import table fails to initialize.

## Fix
- **`resolveNodeLauncher()`** launches via `process.execPath` (VS Code's own bundled Node host) with `ELECTRON_RUN_AS_NODE=1` — removes the PATH dependency entirely and guarantees a matching ABI. Falls back to `'node'` if `execPath` is unavailable (test/non-Electron contexts).
- **`windowsHide: true`** on spawn — avoids console/desktop-heap allocation per spawn, a known `0xC0000142` trigger under rapid restarts.
- **Crash diagnostics** now record the resolved `nodePath`, directly answering the issue's "verify the Node runtime/ABI" next-step.

No native dependencies exist in `mcp-server`, so the failing DLL was in the external `node.exe`'s own load chain — which this change eliminates.

## Tests
- Unit: `resolveNodeLauncher` uses `execPath` + `ELECTRON_RUN_AS_NODE`, preserves env, no mutation; `nodePath` appears in crash diagnostics.
- Regression: **REG-116** (source-level) asserts the launcher path, `ELECTRON_RUN_AS_NODE=1`, `windowsHide`, and that spawn uses the resolved command.
- Full suite: **133/133 green** (built `mcp-server/dist` first — a worktree-only gap, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)