### PR TITLE
fix: increase mobile font sizes 75% on landing page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npx",
       "runtimeArgs": ["serve", "docs/_today", "-p", "4200", "--no-clipboard"],
       "port": 4200
+    },
+    {
+      "name": "cvt-landing",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["serve", ".", "-p", "4201", "--no-clipboard"],
+      "port": 4201
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -343,6 +343,27 @@ footer{
   .mcp-section{padding:32px 24px;margin:0 12px 60px}
   .mcp-inner{grid-template-columns:1fr}
   footer{flex-direction:column;text-align:center}
+  .nav-logo{font-size:1.641rem}
+  .hero-eyebrow{font-size:1.313rem}
+  .hero-sub{font-size:clamp(1.75rem,4.375vw,2.1rem)}
+  .btn{font-size:1.531rem}
+  .stat-l{font-size:1.313rem}
+  .section-label{font-size:1.313rem}
+  .section-sub{font-size:1.641rem}
+  .feature-card h3{font-size:1.75rem}
+  .feature-card p{font-size:1.422rem}
+  .tag{font-size:1.094rem}
+  .mcp-sub{font-size:1.531rem}
+  .mcp-chip{font-size:1.313rem}
+  .mcp-card{font-size:1.313rem}
+  .mcp-card-title{font-size:1.203rem}
+  .terminal-body{font-size:1.422rem}
+  .step h3{font-size:1.641rem}
+  .step p{font-size:1.422rem}
+  .step-num{font-size:1.203rem}
+  .footer-logo{font-size:1.531rem}
+  .footer-links a{font-size:1.422rem}
+  .footer-copy{font-size:1.313rem}
 }
 @media(max-width:480px){
   .stats{flex-direction:column}


### PR DESCRIPTION
## Summary
- Closes #646 — mobile font sizes on the landing page (`index.html`) were too small; increased by 75% (1.75x) via `rem`-based overrides inside the existing 768px mobile media query
- Left headline elements (`.hero h1`, `.section-title`, `.mcp-title`) using `clamp()`/`vw` untouched — they already scale responsively and a further 1.75x would overflow narrow screens

## Test plan
- [x] `node scripts/run-regression-tests.js` — all 132 tests green
- [x] Verified in mobile preview (375x812): nav, hero copy, buttons, stats, feature cards, MCP section, terminal, steps, footer all render larger with no horizontal overflow
- [x] Verified desktop viewport unaffected (font-size unchanged outside the media query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)