### PR TITLE
fix: bump package.json to 1.0.3 to match CHANGELOG.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cielovista-tools",
   "displayName": "CieloVista Tools",
   "description": "CieloVistaSoftware developer toolkit — Copilot utilities, terminal helpers, CSS hover, Python runner, OpenAI chat, and more. One install, one extension.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "CieloVistaSoftware",
   "license": "PROPRIETARY",
   "repository": {


### PR DESCRIPTION
Small follow-up to #657 — the #649 fix added a [1.0.3] CHANGELOG entry (and set the doc frontmatter version to 1.0.3) but never bumped `package.json` itself, so the packaged/installed extension still reported 1.0.2. This just aligns package.json with what the changelog already claims shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)