### PR TITLE
docs: add What's New in 1.0.3 section to marketplace page

### DIFF
--- a/docs/_today/marketplace.html
+++ b/docs/_today/marketplace.html
@@ -178,10 +178,10 @@
 </div>
 <div>
 <h2 class="font-headline-lg text-headline-lg text-on-surface">CieloVista Tools</h2>
-<p class="font-label-sm text-label-sm text-on-surface-variant uppercase tracking-widest">v1.0.2 &nbsp;·&nbsp; Free &nbsp;·&nbsp; VS Code Insiders</p>
+<p class="font-label-sm text-label-sm text-on-surface-variant uppercase tracking-widest">v1.0.3 &nbsp;·&nbsp; Free &nbsp;·&nbsp; VS Code Insiders</p>
 </div>
 </div>
-<a href="cielovista-tools-1.0.2.vsix" download class="shrink-0 h-12 px-8 bg-primary text-on-primary rounded-lg font-label-md hover:opacity-90 transition-opacity active:scale-95 flex items-center gap-sm">
+<a href="cielovista-tools-1.0.3.vsix" download class="shrink-0 h-12 px-8 bg-primary text-on-primary rounded-lg font-label-md hover:opacity-90 transition-opacity active:scale-95 flex items-center gap-sm">
 <span class="material-symbols-outlined">download</span>
 Download VSIX
 </a>
@@ -232,6 +232,25 @@ Download VSIX
 </div>
 <!-- AUTO-GENERATED:INCLUDED-FEATURES:END -->
 </div>
+</div>
+</section>
+<!-- What's New -->
+<section class="mb-xl">
+<div class="flex items-center justify-between mb-md">
+<h2 class="font-headline-lg text-headline-lg text-on-surface">What's new in 1.0.3</h2>
+<a href="../../CHANGELOG.md" class="font-label-md text-label-md text-primary hover:underline">Full changelog</a>
+</div>
+<div class="bg-surface-container-lowest rounded-xl border border-outline-variant/30 p-lg">
+<ul class="grid grid-cols-1 md:grid-cols-2 gap-sm">
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">✨</span>New Session Activity Dashboard — live rollup of current focus, active work, deploy pushes, CI status, and open issues</li>
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">🛠️</span>Marketplace "What's inside" now generated from the command catalog (121 commands, 13 groups) instead of 4 hardcoded cards</li>
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">🛠️</span>Preview/Start button now cache-busts every launch so edits show up without a manual hard-reload</li>
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">🛠️</span>BYOK main model no longer errors on Copilot's internal utility-only models</li>
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">🛠️</span>Marketplace Compliance now catches stale (not just missing) CHANGELOG.md files</li>
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">🐛</span>Fixed false-positive regression failures and health-state save errors from bg-health-runner</li>
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">🐛</span>Fixed a silent MCP server crash that discarded its own error message on exit</li>
+<li class="flex items-start gap-sm text-on-surface-variant font-body-md"><span class="text-primary" aria-hidden="true">🐛</span>Fixed untagged code-fence warnings across project docs</li>
+</ul>
 </div>
 </section>
 <!-- Feature Cards -->


### PR DESCRIPTION
Follow-up to #658 — adds a curated "What's new in 1.0.3" highlight section to `docs/_today/marketplace.html` (the changelog alone wasn't a great answer to "what's new" for a browsing user), and syncs the hand-maintained version label/download-filename to 1.0.3 (these aren't covered by the #644 catalog-driven generator).

Verified rendering in-browser: dark theme intact, no hardcoded colors, section flows correctly above the existing feature-card grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)