### PR TITLE
fix: sync stale version/stat numbers on the live .io landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,7 +390,7 @@ footer{
     <a href="#mcp">MCP Server</a>
     <a href="#quickstart">Quick Start</a>
     <a href="https://github.com/CieloVistaSoftware/CIELOVISTA-TOOLS">GitHub</a>
-    <span class="nav-badge">v1.0.2</span>
+    <span class="nav-badge">v1.0.3</span>
   </div>
 </nav>
 
@@ -414,10 +414,10 @@ footer{
 
 <!-- ── Stats ────────────────────────────────────────────────────────────── -->
 <div class="stats">
-  <div class="stat"><span class="stat-n">128</span><span class="stat-l">Commands</span></div>
-  <div class="stat"><span class="stat-n">40+</span><span class="stat-l">Features</span></div>
+  <div class="stat"><span class="stat-n">131</span><span class="stat-l">Commands</span></div>
+  <div class="stat"><span class="stat-n">63+</span><span class="stat-l">Features</span></div>
   <div class="stat"><span class="stat-n">1</span><span class="stat-l">Install</span></div>
-  <div class="stat"><span class="stat-n">69</span><span class="stat-l">Tests Green</span></div>
+  <div class="stat"><span class="stat-n">138</span><span class="stat-l">Tests Green</span></div>
   <div class="stat"><span class="stat-n">∞</span><span class="stat-l">Projects Supported</span></div>
 </div>
 
@@ -561,7 +561,7 @@ footer{
     <div class="step fade-in">
       <span class="step-num">STEP 02</span>
       <h3>Run rebuild</h3>
-      <p><code style="color:#58a6ff">npm run rebuild</code> compiles TypeScript, runs 69 regression tests, packages the VSIX, and installs it.</p>
+      <p><code style="color:#58a6ff">npm run rebuild</code> compiles TypeScript, runs 138 regression tests, packages the VSIX, and installs it.</p>
     </div>
     <div class="step fade-in">
       <span class="step-num">STEP 03</span>
@@ -598,7 +598,7 @@ footer{
       <div><span class="t-prompt">PS&gt;</span> <span class="t-cmd">npm run rebuild</span></div>
       <br>
       <div><span class="t-out">  Compiling TypeScript...</span></div>
-      <div><span class="t-out">  Running 69 regression tests...</span></div>
+      <div><span class="t-out">  Running 138 regression tests...</span></div>
       <div><span class="t-ok">  ✓ All tests passed</span></div>
       <div><span class="t-ok">  ✓ Extension installed → VS Code Insiders</span></div>
       <br>

--- a/scripts/sync-doc-versions.js
+++ b/scripts/sync-doc-versions.js
@@ -1,17 +1,21 @@
 'use strict';
 // Copyright (c) CieloVista Software. All rights reserved.
 //
-// Keeps the VSIX filename and the extension's own version label shown in
-// docs/_today/*.html demo pages in sync with package.json, so a version bump
-// can't leave a stale "cielovista-tools-X.Y.Z.vsix" download link behind
-// again (this has happened twice by hand — see #658/#659).
+// Keeps the version number, VSIX filename, and command/feature counts shown
+// in docs/_today/*.html and the repo-root index.html (the actual live .io
+// landing page — GitHub Pages serves branch=main, path=/) in sync with
+// package.json/src, so a version bump or new feature can't leave stale
+// numbers behind again (this has happened three times by hand now — see
+// #658/#659/#660, plus the 128/40+/69 landing-page stats caught in review).
 //
-// Deliberately narrow: only the VSIX filename (always unambiguous — this
-// extension is the only thing named cielovista-tools-*.vsix) and the
-// marketplace hero's own version label are touched. docs/_today/console.html
-// lists several *other* mock tools with their own independent demo version
-// numbers (File List, Copilot Rules, MCP Viewer, ...) that must never be
-// clobbered by a blanket "vX.Y.Z" replacement.
+// Deliberately narrow: only unambiguous, cheaply-derivable values are
+// touched (VSIX filename, version labels, command count, feature count).
+// docs/_today/console.html lists several *other* mock tools with their own
+// independent demo version numbers (File List, Copilot Rules, MCP Viewer,
+// ...) that must never be clobbered by a blanket "vX.Y.Z" replacement.
+// Regression test count is NOT auto-synced here — it changes with nearly
+// every PR and computing it live would mean running the full suite inside
+// this lightweight doc step; review "Tests Green" by hand each release.
 
 const fs = require('fs');
 const path = require('path');
@@ -22,13 +26,32 @@ const DOCS_TODAY = path.join(ROOT, 'docs', '_today');
 // Anchored so only this extension's own hero label ever matches — never a
 // bare "vX.Y.Z" anywhere else in the page.
 const HERO_LABEL_RE = /(CieloVista Tools<\/h2>\s*<p[^>]*>)v\d+\.\d+\.\d+(?=\s|&nbsp;)/;
+const NAV_BADGE_RE = /(<span class="nav-badge">)v\d+\.\d+\.\d+(<\/span>)/;
+const COMMANDS_STAT_RE = /(<span class="stat-n">)\d+(<\/span><span class="stat-l">Commands<\/span>)/;
+const FEATURES_STAT_RE = /(<span class="stat-n">)\d+\+?(<\/span><span class="stat-l">Features<\/span>)/;
 
-/** @param {string} version */
-function syncFile(filePath, version) {
+function countFeatures() {
+    const featuresDir = path.join(ROOT, 'src', 'features');
+    const entries = fs.readdirSync(featuresDir, { withFileTypes: true });
+    const flatFiles = entries.filter((e) => e.isFile() && e.name.endsWith('.ts')).length;
+    const subFeatures = entries.filter(
+        (e) => e.isDirectory() && (fs.existsSync(path.join(featuresDir, e.name, 'index.ts')) || fs.existsSync(path.join(featuresDir, e.name, 'feature.ts')))
+    ).length;
+    return flatFiles + subFeatures;
+}
+
+/**
+ * @param {string} filePath
+ * @param {{version: string, commandCount: number, featureCount: number}} facts
+ */
+function syncFile(filePath, facts) {
     const before = fs.readFileSync(filePath, 'utf8');
     const after = before
-        .replace(/cielovista-tools-\d+\.\d+\.\d+\.vsix/g, `cielovista-tools-${version}.vsix`)
-        .replace(HERO_LABEL_RE, `$1v${version}`);
+        .replace(/cielovista-tools-\d+\.\d+\.\d+\.vsix/g, `cielovista-tools-${facts.version}.vsix`)
+        .replace(HERO_LABEL_RE, `$1v${facts.version}`)
+        .replace(NAV_BADGE_RE, `$1v${facts.version}$2`)
+        .replace(COMMANDS_STAT_RE, `$1${facts.commandCount}$2`)
+        .replace(FEATURES_STAT_RE, `$1${facts.featureCount}+$2`);
     if (after !== before) {
         fs.writeFileSync(filePath, after, 'utf8');
         return true;
@@ -42,18 +65,26 @@ function main() {
     if (!version) {
         throw new Error('package.json has no version field');
     }
+    const facts = {
+        version,
+        commandCount: pkg.contributes.commands.length,
+        featureCount: countFeatures(),
+    };
 
-    const htmlFiles = fs.readdirSync(DOCS_TODAY).filter((f) => f.endsWith('.html'));
+    const files = [
+        path.join(ROOT, 'index.html'),
+        ...fs.readdirSync(DOCS_TODAY).filter((f) => f.endsWith('.html')).map((f) => path.join(DOCS_TODAY, f)),
+    ].filter((f) => fs.existsSync(f));
+
     let changedCount = 0;
-    for (const file of htmlFiles) {
-        const full = path.join(DOCS_TODAY, file);
-        if (syncFile(full, version)) {
+    for (const full of files) {
+        if (syncFile(full, facts)) {
             changedCount++;
             console.log(`  updated ${path.relative(ROOT, full)}`);
         }
     }
 
-    console.log(`\nsync-doc-versions: ${version} — ${changedCount} file(s) updated, ${htmlFiles.length} scanned`);
+    console.log(`\nsync-doc-versions: v${facts.version}, ${facts.commandCount} commands, ${facts.featureCount} features — ${changedCount} file(s) updated, ${files.length} scanned`);
 }
 
 main();


### PR DESCRIPTION
The real GitHub Pages landing page at https://cielovistasoftware.github.io/CIELOVISTA-TOOLS/ is the repo-root `index.html` (Pages source: branch=main, path=/) — not `docs/_today/*.html`, which I'd been treating as the marketplace page all session. It still showed v1.0.2 and old stats: 128 commands (now 131), 40+ features (now 63+), 69 tests green (now 138). Its 'Get the Extension' link was already correct — points to /releases, not a broken relative vsix path.

Extends `scripts/sync-doc-versions.js` to also sync index.html's version badge, command count, and feature count from package.json/src/features. Test count stays a manual review item (documented in the script) since computing it live would mean running the full suite inside a lightweight doc step.

Test plan:
- [x] Verified in-browser: v1.0.3, 131 commands, 63+ features, 138 tests green
- [x] node scripts/run-regression-tests.js — 138/138 passing
- [x] Downloaded the actual v1.0.3 VSIX from the published GitHub Release and installed it via the VS Code CLI to confirm the real end-to-end install path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)