### PR TITLE
docs: add live .io site link to top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+https://cielovistasoftware.github.io/CIELOVISTA-TOOLS/
+
 # CieloVista Tools
 One VS Code extension. One install. Your folder of projects — unified.
 


### PR DESCRIPTION
John had made this edit locally in his own checkout of the main repo directory — not any worktree this session touched, which is why it never landed in earlier commits. Applying it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)