### PR TITLE
fix: Command Validation orphan rows show correct package.json path (#665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented here.
 
 ### Fixed
 
+- Command Validation report (`cvs.commands.validate`): orphan-command rows showed a garbled Source path (resolved against the extension host's `process.cwd()` instead of the workspace root) because `sourceFile` was stored as a bare `'package.json'` literal instead of an absolute path (#665)
 - bg-health-runner reported false regression failures (8 REG checks, ×56 occurrences) from a transient race scanning an unsettled git worktree; now retries once before filing a bug (#641, #652)
 - 2 untagged fenced code blocks in project docs tagged correctly (#645, #637)
 - `bg-health.json` save failures hardened: atomic write (temp file + rename), exponential backoff after repeated failures, richer error logging (#651)

--- a/src/features/command-validator.ts
+++ b/src/features/command-validator.ts
@@ -226,7 +226,7 @@ async function runValidation(root: string): Promise<CmdResult[]> {
         if (!seenInReadme.has(id)) {
             results.push({
                 commandId:  id,
-                sourceFile: 'package.json',
+                sourceFile: path.join(root, 'package.json'),
                 status:     'orphan',
                 detail:     'Registered in package.json but not documented in any feature README',
             });

--- a/tests/regression/REG-101-command-validator.test.js
+++ b/tests/regression/REG-101-command-validator.test.js
@@ -38,6 +38,9 @@ check('runValidation detects missing-pkg status',
 check('runValidation detects orphan commands',
     SRC.includes("'orphan'"));
 
+check('orphan rows use an absolute sourceFile path (path.join(root, ...)), not a bare literal (#665)',
+    SRC.includes("sourceFile: path.join(root, 'package.json')"));
+
 check('syncTagsForFile merges tags without removing existing ones',
     SRC.includes('syncTagsForFile') && SRC.includes('existingTags.push'));
 


### PR DESCRIPTION
## Summary
- Fixes #665 — the `cvs.commands.validate` webview's "Orphan Commands" table rendered a garbled Source path (`../../../../AppData/Local/Programs/Microsoft VS Code Insiders/package.json`) instead of the workspace's `package.json`.
- Root cause: `sourceFile` for orphan rows was the bare literal `'package.json'`; `buildValidationHtml`'s `rel()` helper resolves relative strings against `process.cwd()` (the extension host's cwd — the VS Code Insiders install dir), not against `root`.
- Fix: store the orphan row's `sourceFile` as `path.join(root, 'package.json')` (absolute), matching every other row.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `node tests/regression/REG-101-command-validator.test.js` — 23/23 passed (new check added: orphan rows use an absolute sourceFile path, tied to #665)
- [x] `node scripts/run-regression-tests.js` — all 138 regression tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)