### PR TITLE
fix: recover main repo folder from laptop-crash detached HEAD (#672)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,15 @@
       "runtimeExecutable": "npx",
       "runtimeArgs": ["serve", ".", "-p", "4201", "--no-clipboard"],
       "port": 4201
+    },
+    {
+      "name": "wb-starter",
+      "runtimeExecutable": "node",
+      "runtimeArgs": [
+        "C:/Users/jwpmi/Downloads/AI/wb-starter/server.js"
+      ],
+      "port": 3000,
+      "autoPort": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Closes #672
- Main repo folder was detached at an old commit (15 behind `main`), showing 87 files with stale pre-tags-enrichment frontmatter (all safely reproducible from `main` — not real corruption)
- Reset working tree to match `origin/main`; re-added the local `wb-starter` dev server config into `.claude/launch.json` as an additional entry (kept `cvt-demo`/`cvt-landing`)

## Test plan
- [x] `npm run compile` succeeds
- [x] `.claude/launch.json` has all three configs (`cvt-demo`, `cvt-landing`, `wb-starter`)
- [x] `git status` clean in the main repo folder

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>