### PR TITLE
fix: replace hardcoded jwpmi-username paths with os.homedir()

### DIFF
--- a/mcp-server/src/tools/catalog-helpers.ts
+++ b/mcp-server/src/tools/catalog-helpers.ts
@@ -3,6 +3,7 @@
 // self-contained from the extension's webview-focused catalog code.
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -52,8 +53,12 @@ interface ProjectDewey {
 
 // ─── Registry ───────────────────────────────────────────────────────────────
 
-export const REGISTRY_PATH =
-  "C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json";
+export const REGISTRY_PATH = path.join(
+  os.homedir(),
+  "Downloads",
+  "CieloVistaStandards",
+  "project-registry.json"
+);
 
 export function loadRegistry(): ProjectRegistry {
   if (!fs.existsSync(REGISTRY_PATH)) {
@@ -1372,8 +1377,12 @@ export interface DocLedgerResult {
   index: DocIdentityEntry[];
 }
 
-const ALIAS_PATH =
-  "C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\dewey-aliases.json";
+const ALIAS_PATH = path.join(
+  os.homedir(),
+  "Downloads",
+  "CieloVistaStandards",
+  "dewey-aliases.json"
+);
 
 function loadAliases(): Record<string, string> {
   try {

--- a/scripts/code-auditor.js
+++ b/scripts/code-auditor.js
@@ -12,10 +12,11 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 const DEFAULTS = {
     minLines: 5,
     minStatements: 3,

--- a/scripts/fix-docid-collisions.js
+++ b/scripts/fix-docid-collisions.js
@@ -7,9 +7,10 @@
 'use strict';
 
 const fs   = require('fs');
+const os   = require('os');
 const path = require('path');
 
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 const SKIP_DIRS  = new Set(['node_modules', '.git', 'out', 'dist', '.vscode', '.vscode-test', '.claude', 'reports', 'CommandHelp', 'image-reader-assets']);
 const SKIP_FILES = new Set(['.gitignore', '.gitattributes']);
 const DRY_RUN    = process.argv.includes('--dry-run');

--- a/scripts/run-audit.js
+++ b/scripts/run-audit.js
@@ -11,7 +11,7 @@
 //   node scripts/run-audit.js --verbose
 //
 // Output:
-//   Writes C:\Users\jwpmi\Downloads\CieloVistaStandards\reports\daily-audit.json
+//   Writes %USERPROFILE%\Downloads\CieloVistaStandards\reports\daily-audit.json
 //   Exits 0 on success, 1 on failure.
 //
 // To install as a Windows Scheduled Task (run once as admin):
@@ -23,10 +23,12 @@
 'use strict';
 
 const fs   = require('fs');
+const os   = require('os');
 const path = require('path');
 
-const REGISTRY_PATH  = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
-const REPORT_PATH    = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\reports\\daily-audit.json';
+const STANDARDS_DIR  = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards');
+const REGISTRY_PATH  = path.join(STANDARDS_DIR, 'project-registry.json');
+const REPORT_PATH    = path.join(STANDARDS_DIR, 'reports', 'daily-audit.json');
 const VERBOSE        = process.argv.includes('--verbose');
 const STALE_DAYS     = 30;
 const OPEN_SRC_LICS  = ['MIT','ISC','Apache-2.0','GPL-2.0','GPL-3.0','BSD-2-Clause','BSD-3-Clause'];

--- a/scripts/verify-registry-promote.js
+++ b/scripts/verify-registry-promote.js
@@ -60,7 +60,7 @@ module.exports = {
 const promoteModule = require(path.join(__dirname, '..', 'out', 'features', 'registry-promote.js'));
 const { promoteFolder } = promoteModule;
 
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 function readRegistry() {
   return JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));

--- a/src/features/cvs-command-launcher/catalog.ts
+++ b/src/features/cvs-command-launcher/catalog.ts
@@ -3,11 +3,13 @@
 
 // component: cmd
 
+import * as os from 'os';
+import * as path from 'path';
 import type { CmdEntry } from './types';
 import { buildRunTooltip } from './tooltip-builder';
 
 // Base path for feature README files
-const F = 'C:\\Users\\jwpmi\\Downloads\\VSCode\\projects\\cielovista-tools\\src\\features\\';
+const F = path.join(os.homedir(), 'Downloads', 'VSCode', 'projects', 'cielovista-tools', 'src', 'features') + path.sep;
 export const README = (name: string): string => `${F}${name}.README.md`;
 
 const RAW_CATALOG: CmdEntry[] = [

--- a/src/features/cvs-command-launcher/index.ts
+++ b/src/features/cvs-command-launcher/index.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from 'vscode';
 import * as fs   from 'fs';
+import * as os   from 'os';
 import * as path from 'path';
 import { log, logError, getChannel } from '../../shared/output-channel';
 import { loadLastReport }      from '../daily-audit/runner';
@@ -27,9 +28,9 @@ const FEATURE             = 'cvs-command-launcher';
 const LAUNCHER_COMMAND_ID = 'cvs.commands.showAll';
 const QUICKRUN_COMMAND_ID = 'cvs.commands.quickRun';
 
-const _DISKCLEANUP_ROOT = 'C:\\Users\\jwpmi\\source\\repos\\DiskCleanUp';
+const _DISKCLEANUP_ROOT = path.join(os.homedir(), 'source', 'repos', 'DiskCleanUp');
 const _DISKCLEANUP_SVC  = path.join(_DISKCLEANUP_ROOT, 'DiskCleanUp.Service');
-const _SNAPIT_ROOT      = 'C:\\Users\\jwpmi\\source\\repos\\SnapIt';
+const _SNAPIT_ROOT      = path.join(os.homedir(), 'source', 'repos', 'SnapIt');
 const _SNAPIT_SVC       = path.join(_SNAPIT_ROOT, 'SnapIt.Service');
 const _SNAPIT_TRAY      = path.join(_SNAPIT_ROOT, 'SnapIt.Tray');
 

--- a/src/features/daily-audit/runner.ts
+++ b/src/features/daily-audit/runner.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs   from 'fs';
+import * as os   from 'os';
 import * as path from 'path';
 import { runMarketplaceCheck    } from './checks/marketplace';
 import { runReadmeQualityCheck  } from './checks/readme-quality';
@@ -25,7 +26,7 @@ import { runTestCoverageCheck   } from './checks/test-coverage';
 import type { DailyAuditReport, AuditCheck } from '../../shared/audit-schema';
 import { AUDIT_REPORT_PATH } from '../../shared/audit-schema';
 
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 interface ProjectEntry {
     name: string;

--- a/src/features/doc-auditor/collector.ts
+++ b/src/features/doc-auditor/collector.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { DocFile } from './types';
 
@@ -17,7 +18,7 @@ export function getReportDir(): string {
     const ws = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const dir = ws
         ? path.join(ws, 'docs')
-        : 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\reports';
+        : path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'reports');
     if (!fs.existsSync(dir)) { fs.mkdirSync(dir, { recursive: true }); }
     return dir;
 }

--- a/src/features/doc-auditor/report.ts
+++ b/src/features/doc-auditor/report.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as fs     from 'fs';
+import * as os     from 'os';
 import * as path   from 'path';
 import { log }     from '../../shared/output-channel';
 import type { AuditResults, ParsedAction } from './types';
@@ -13,7 +14,7 @@ const FEATURE = 'doc-auditor';
 
 export function getReportDir(): string {
     const ws  = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    const dir = ws ? path.join(ws, 'docs') : 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\reports';
+    const dir = ws ? path.join(ws, 'docs') : path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'reports');
     if (!fs.existsSync(dir)) { fs.mkdirSync(dir, { recursive: true }); }
     return dir;
 }

--- a/src/features/doc-consolidator/feature.ts
+++ b/src/features/doc-consolidator/feature.ts
@@ -40,6 +40,7 @@
  */
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { log, logError } from '../../shared/output-channel';
 import { REGISTRY_PATH, loadRegistry, ProjectRegistry, ProjectEntry } from '../../shared/registry';
@@ -57,7 +58,7 @@ const INTENTIONAL_DUPLICATES = new Set([
 ]);
 
 const FEATURE = 'doc-consolidator';
-const GLOBAL_DOCS    = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards';
+const GLOBAL_DOCS    = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards');
 const CONSOLIDATION_LOG = path.join(GLOBAL_DOCS, 'consolidation-log.md');
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/features/doc-header-scan.ts
+++ b/src/features/doc-header-scan.ts
@@ -9,11 +9,12 @@
  */
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { log, logError } from '../shared/output-channel';
 
 const FEATURE = 'doc-header-scan';
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 interface ProjectEntry {
     name: string;

--- a/src/features/doc-header/feature.ts
+++ b/src/features/doc-header/feature.ts
@@ -44,14 +44,15 @@
  */
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { log, logError } from '../../shared/output-channel';
 import { esc } from '../../shared/webview-utils';
 import { CATEGORIES } from '../../shared/categories';
 
 const FEATURE       = 'doc-header';
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
-const GLOBAL_DOCS   = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards';
+const GLOBAL_DOCS   = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards');
+const REGISTRY_PATH = path.join(GLOBAL_DOCS, 'project-registry.json');
 const TODAY         = new Date().toISOString().slice(0, 10);
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/features/doc-intelligence/commands.ts
+++ b/src/features/doc-intelligence/commands.ts
@@ -32,6 +32,7 @@ export async function executeAcceptedFindings(findings: Finding[]): Promise<numb
 
 import * as vscode from 'vscode';
 import * as fs     from 'fs';
+import * as os     from 'os';
 import * as path   from 'path';
 import { log, logError } from '../../shared/output-channel';
 import { collectArtifactFolders, collectDocs } from './scanner';
@@ -43,8 +44,9 @@ import type {
 } from './types';
 
 const FEATURE       = 'doc-intelligence';
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
-const LOG_PATH      = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\reports\\intelligence-log.md';
+const STANDARDS_DIR = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards');
+const REGISTRY_PATH = path.join(STANDARDS_DIR, 'project-registry.json');
+const LOG_PATH      = path.join(STANDARDS_DIR, 'reports', 'intelligence-log.md');
 
 let _panel:     vscode.WebviewPanel | undefined;
 let _report:    IntelligenceReport  | undefined;

--- a/src/features/docs-manager.ts
+++ b/src/features/docs-manager.ts
@@ -9,10 +9,10 @@
  * documentation across EVERY CieloVista project from any workspace.
  *
  * The master project registry lives at:
- *   C:\Users\jwpmi\Downloads\CieloVistaStandards\project-registry.json
+ *   %USERPROFILE%\Downloads\CieloVistaStandards\project-registry.json
  *
  * Global standards docs live at:
- *   C:\Users\jwpmi\Downloads\CieloVistaStandards\
+ *   %USERPROFILE%\Downloads\CieloVistaStandards\
  *
  * Commands registered:
  *   cvs.docs.openGlobal      — open any global standards doc
@@ -266,7 +266,7 @@ function buildSyncIssues(project: ProjectEntry, globalDocsPath: string): SyncIss
             key:       'no-global-ref',
             label:     'CLAUDE.md does not reference global standards',
             tooltip:   'CLAUDE.md should point Claude to CieloVistaStandards so it reads the global coding rules, git workflow, and web component guide at the start of every session.',
-            howToFix:  'Add a "Global Standards" section to CLAUDE.md referencing C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards.',
+            howToFix:  `Add a "Global Standards" section to CLAUDE.md referencing ${path.dirname(REGISTRY_PATH)}.`,
             fixLabel:  'Add Reference',
             fixAction: 'addGlobalRef',
             fixData:   claudePath,

--- a/src/features/js-error-audit.ts
+++ b/src/features/js-error-audit.ts
@@ -26,6 +26,7 @@ import * as vscode from 'vscode';
 import * as fs     from 'fs';
 import * as path   from 'path';
 import { execSync } from 'child_process';
+import * as os from 'os';
 import { log, logError } from '../shared/output-channel';
 import { loadRegistry }  from '../shared/registry';
 import { esc }           from '../shared/webview-utils';
@@ -81,7 +82,7 @@ function findDiskCleanUpRoot(): string | undefined {
         );
         if (entry && fs.existsSync(entry.path)) { return entry.path; }
     }
-    const fallback = 'C:\\Users\\jwpmi\\source\\repos\\DiskCleanUp';
+    const fallback = path.join(os.homedir(), 'source', 'repos', 'DiskCleanUp');
     if (fs.existsSync(fallback)) { return fallback; }
     return undefined;
 }

--- a/src/features/license-sync.ts
+++ b/src/features/license-sync.ts
@@ -19,13 +19,14 @@
 
 import * as vscode from 'vscode';
 import * as fs     from 'fs';
+import * as os     from 'os';
 import * as path   from 'path';
 import { log, logError } from '../shared/output-channel';
 import { REGISTRY_PATH, loadRegistry, ProjectEntry } from '../shared/registry';
 import { esc } from '../shared/webview-utils';
 
 const FEATURE        = 'license-sync';
-const CANONICAL_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\LICENSE';
+const CANONICAL_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'LICENSE');
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/src/features/marketplace-compliance/registry.ts
+++ b/src/features/marketplace-compliance/registry.ts
@@ -1,10 +1,12 @@
 // Copyright (c) 2025 CieloVista Software. All rights reserved.
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { logError } from '../../shared/output-channel';
 import type { ProjectRegistry } from './types';
 
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 export function loadRegistry(): ProjectRegistry | undefined {
     try {

--- a/src/features/readme-compliance/feature.ts
+++ b/src/features/readme-compliance/feature.ts
@@ -11,7 +11,7 @@
  * real before/after diff in a webview. User must click Approve or Ignore
  * per fix — nothing is ever written without explicit approval.
  *
- * Standard: C:\Users\jwpmi\Downloads\CieloVistaStandards\README-STANDARD.md
+ * Standard: %USERPROFILE%\Downloads\CieloVistaStandards\README-STANDARD.md
  *
  * Three README types are recognized:
  *   PROJECT  — README.md at project root
@@ -32,6 +32,7 @@
  */
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as jsdiff from 'diff';
 import { log, logError } from '../../shared/output-channel';
@@ -40,7 +41,7 @@ import { loadRegistry } from '../../shared/registry';
 import { esc } from '../../shared/webview-utils';
 
 const FEATURE     = 'readme-compliance';
-const GLOBAL_DOCS = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards';
+const GLOBAL_DOCS = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards');
 const STANDARD_PATH = path.join(GLOBAL_DOCS, 'README-STANDARD.md');
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/features/readme-compliance/sections.ts
+++ b/src/features/readme-compliance/sections.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 CieloVista Software. All rights reserved.
 /** Required sections, ordering, line limits, and stub templates for README compliance. */
+import * as os from 'os';
+import * as path from 'path';
 import type { ReadmeType } from './types';
 
 export const REQUIRED_SECTIONS: Record<ReadmeType, string[]> = {
@@ -16,7 +18,7 @@ export const SECTION_ORDER: Record<ReadmeType, string[]> = {
 
 export const LINE_LIMITS: Record<ReadmeType, number> = { PROJECT: 300, FEATURE: 150, STANDARD: 400 };
 
-const GLOBAL_DOCS = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards';
+const GLOBAL_DOCS = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards');
 
 export const STUBS: Record<ReadmeType, Record<string, string>> = {
     PROJECT: {

--- a/src/features/registry-promote.ts
+++ b/src/features/registry-promote.ts
@@ -24,11 +24,13 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { log, logError } from '../shared/output-channel';
 import { REGISTRY_PATH, loadRegistry, saveRegistry, ProjectEntry } from '../shared/registry';
 
 const FEATURE = 'registry-promote';
+const GLOBAL_DOCS_DIR = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards');
 
 const PROJECT_TYPES: readonly string[] = [
     'vscode-extension',
@@ -127,9 +129,9 @@ function buildClaudeMd(projectName: string, projectPath: string): string {
         '',
         '| Document | Location |',
         '|---|---|',
-        '| Copilot Rules | `C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\copilot-rules.md` |',
-        '| JavaScript Standards | `C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\javascript_standards.md` |',
-        '| Git Workflow | `C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\git_workflow.md` |',
+        `| Copilot Rules | \`${path.join(GLOBAL_DOCS_DIR, 'copilot-rules.md')}\` |`,
+        `| JavaScript Standards | \`${path.join(GLOBAL_DOCS_DIR, 'javascript_standards.md')}\` |`,
+        `| Git Workflow | \`${path.join(GLOBAL_DOCS_DIR, 'git_workflow.md')}\` |`,
         `| Project Registry | \`${REGISTRY_PATH}\` |`,
         '',
     ].join('\n');

--- a/src/shared/audit-schema.ts
+++ b/src/shared/audit-schema.ts
@@ -10,6 +10,9 @@
  * Rule: nothing reads or writes audit data except through these types.
  */
 
+import * as os from 'os';
+import * as path from 'path';
+
 export type AuditStatus = 'green' | 'yellow' | 'red' | 'grey';
 
 /**
@@ -67,4 +70,4 @@ export interface DailyAuditReport {
 
 /** Path where the audit report is always written. Both consumers read from here. */
 export const AUDIT_REPORT_PATH =
-    'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\reports\\daily-audit.json';
+    path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'reports', 'daily-audit.json');

--- a/src/shared/cvt-registry.ts
+++ b/src/shared/cvt-registry.ts
@@ -4,7 +4,7 @@
  * cvt-registry.ts
  *
  * Read/write helpers for the CVT project registry at
- *   C:\Users\jwpmi\Downloads\CieloVistaStandards\project-registry.json
+ *   %USERPROFILE%\Downloads\CieloVistaStandards\project-registry.json
  *
  * This is the same file read by the MCP server's catalog-helpers. The MCP
  * server runs in a separate Node process and re-reads the file on every
@@ -17,6 +17,7 @@
  */
 
 import * as fs   from 'fs';
+import * as os   from 'os';
 import * as path from 'path';
 
 export interface ProjectEntry {
@@ -24,7 +25,7 @@ export interface ProjectEntry {
     path:         string;
     type:         string;
     description:  string;
-    status?:      'product' | 'workbench' | 'generated' | 'archived';
+    status?:      'product' | 'workbench' | 'generated' | 'archived' | 'container';
 }
 
 export interface ProjectRegistry {
@@ -33,7 +34,7 @@ export interface ProjectRegistry {
 }
 
 export const REGISTRY_PATH =
-    'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+    path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 /** Read the registry JSON. Throws if the file is missing or unparseable. */
 export function loadRegistry(): ProjectRegistry {

--- a/src/shared/registry.ts
+++ b/src/shared/registry.ts
@@ -4,10 +4,12 @@
 // Exports the canonical REGISTRY_PATH and loadRegistry() utility for all features.
 // Ensures single source of truth for project registry location and loading logic.
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
-// Path to the canonical project registry JSON file
-export const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+// Path to the canonical project registry JSON file, portable across Windows accounts
+export const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 export interface ProjectEntry {
     name:        string;
@@ -15,7 +17,7 @@ export interface ProjectEntry {
     type:        string;
     description: string;
     /** Lifecycle status. Missing entries default to "product" for backward compatibility. */
-    status?:     'product' | 'workbench' | 'generated' | 'archived';
+    status?:     'product' | 'workbench' | 'generated' | 'archived' | 'container';
 }
 
 export interface ProjectRegistry {

--- a/tests/.fake-vscode-adapter.js
+++ b/tests/.fake-vscode-adapter.js
@@ -1,5 +1,5 @@
 const path = require('path');
-     const repoRoot = "C:\\Users\\jwpmi\\Downloads\\VSCode\\projects\\cielovista-tools";
+     const repoRoot = path.resolve(__dirname, '..');
      module.exports = {
          workspace: { workspaceFolders: [{ uri: { fsPath: repoRoot }, name: 'cielovista-tools' }] },
          window: {}, ViewColumn: { One: 1 }, Uri: { parse: s => ({ toString: () => s }) }, env: {}

--- a/tests/install-verify.test.js
+++ b/tests/install-verify.test.js
@@ -114,7 +114,7 @@ ok('Extension bundle out/extension.js is non-trivial (>500KB)', bundleSize > 500
 // project-registry.json is the developer's own personal project list -- it
 // only ever exists on their machine, never on a CI runner. Skip this whole
 // section under CI rather than failing on every single run.
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 let registry = null;
 if (process.env.CI) {
     console.log('  SKIP: project-registry.json checks (personal file, not present on CI runners)');
@@ -282,7 +282,7 @@ ok('#302 Smart fixer guessLanguage + LANG_HINTS exist in source',
         console.log('  SKIP: #304 Zero docid collisions (personal registry file, not present on CI runners)');
         return;
     }
-    const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+    const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
     const SKIP_DIRS = new Set(['node_modules', '.git', 'bin', 'out', 'dist', '.vscode', '.vscode-test', '.claude', 'reports', 'CommandHelp', 'image-reader-assets']);
     let reg;
     try { reg = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8')); } catch { ok('#304 Zero docid collisions (registry loads)', false, 'Could not read registry'); return; }

--- a/tests/regression/REG-024-daily-audit-excluded.test.js
+++ b/tests/regression/REG-024-daily-audit-excluded.test.js
@@ -6,11 +6,12 @@
 'use strict';
 
 const fs   = require('fs');
+const os   = require('os');
 const path = require('path');
 const assert = require('assert');
 
 const ROOT          = path.resolve(__dirname, '..', '..');
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 let passed = 0;
 let failed = 0;

--- a/tests/regression/REG-027-doc-catalog-no-collisions.test.js
+++ b/tests/regression/REG-027-doc-catalog-no-collisions.test.js
@@ -7,10 +7,11 @@
 'use strict';
 
 const fs   = require('fs');
+const os   = require('os');
 const path = require('path');
 const assert = require('assert');
 
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 const SKIP_DIRS  = new Set(['node_modules', '.git', 'bin', 'out', 'dist', '.vscode', '.vscode-test', '.claude', 'reports', 'CommandHelp', 'image-reader-assets']);
 const SKIP_FILES = new Set(['.gitignore', '.gitattributes']);
 

--- a/tests/test-coverage-commands.integration.test.js
+++ b/tests/test-coverage-commands.integration.test.js
@@ -9,7 +9,7 @@ const path = require('path');
 const fs = require('fs');
 const { execSync } = require('child_process');
 
-const WORKSPACE_ROOT = 'C:\\Users\\jwpmi\\Downloads\\VSCode\\projects\\cielovista-tools';
+const WORKSPACE_ROOT = path.resolve(__dirname, '..');
 const SCRIPT_PATH = path.join(WORKSPACE_ROOT, 'scripts', 'audit-test-coverage.js');
 const SCRIPT_CMD = `node "${SCRIPT_PATH}" --json`;
 

--- a/tests/unit/daily-audit-checks.test.js
+++ b/tests/unit/daily-audit-checks.test.js
@@ -22,7 +22,7 @@ const fs     = require('fs');
 const os     = require('os');
 
 // ── Load compiled modules ─────────────────────────────────────────────────────
-const OUT = 'C:\\Users\\jwpmi\\Downloads\\VSCode\\projects\\cielovista-tools\\out\\features\\daily-audit\\checks';
+const OUT = path.resolve(__dirname, '..', '..', 'out', 'features', 'daily-audit', 'checks');
 
 const modules = {};
 for (const name of ['changelog', 'readme-quality', 'test-coverage', 'registry-health']) {

--- a/tests/unit/doc-contract.test.ts
+++ b/tests/unit/doc-contract.test.ts
@@ -22,10 +22,11 @@
 
 const assert = require('assert');
 const fs     = require('fs');
+const os     = require('os');
 const path   = require('path');
 
 const PROJECT_ROOT = path.join(__dirname, '..', '..');
-const REGISTRY_PATH = 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+const REGISTRY_PATH = path.join(os.homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 // project-registry.json is the developer's own personal project list -- it
 // only ever exists on their machine, never on a CI runner. This scan is

--- a/tests/unit/readme-generator.test.js
+++ b/tests/unit/readme-generator.test.js
@@ -13,15 +13,9 @@ const OUT = path.join(__dirname, '../../out/features/readme-generator.js');
 if (!fs.existsSync(OUT)) { console.error('SKIP: not compiled'); process.exit(0); }
 
 // ── Constants ──────────────────────────────────────────────────────────────────
-// Derive REGISTRY_PATH from source so the test stays in sync with src/shared/registry.ts.
-// The TS source uses \\ escape sequences; convert them to single backslashes as they
-// appear at runtime.
-const registrySrc = path.join(__dirname, '../../src/shared/registry.ts');
-const registryTxt = fs.existsSync(registrySrc) ? fs.readFileSync(registrySrc, 'utf8') : '';
-const _regMatch   = registryTxt.match(/REGISTRY_PATH\s*=\s*'([^']+)'/);
-const REGISTRY_PATH = _regMatch
-    ? _regMatch[1].replace(/\\\\/g, '\\')
-    : 'C:\\Users\\jwpmi\\Downloads\\CieloVistaStandards\\project-registry.json';
+// Mirrors the os.homedir()-based formula in src/shared/registry.ts so the test
+// stays in sync regardless of which account runs it.
+const REGISTRY_PATH = path.join(require('os').homedir(), 'Downloads', 'CieloVistaStandards', 'project-registry.json');
 
 const PROJ_PATH = path.join(require('os').tmpdir(), 'cvt-readme-gen-test-proj');
 


### PR DESCRIPTION
## Summary
- `REGISTRY_PATH` and related `CieloVistaStandards`/repo-self paths were hardcoded to `C:\Users\jwpmi\...` across the shared registry modules, several feature files, the MCP server, standalone scripts, and tests -- blocking install for any Windows account other than jwpmi. This was the registry-portability bug flagged as the remaining gate on public distribution.
- Also fixes 3 test-infra files (`tests/.fake-vscode-adapter.js`, `tests/test-coverage-commands.integration.test.js`, `tests/unit/daily-audit-checks.test.js`) that hardcoded this repo's own checkout location instead of resolving it relative to `__dirname` -- these broke when run from a worktree instead of the main checkout.
- Adds `'container'` to the registry `status` union type (`src/shared/registry.ts`, `src/shared/cvt-registry.ts`) to match real registry data -- the type was silently missing a status value that's actually in use by 8 projects.

Left untouched: ~9 one-off dev/debug scratch scripts under `scripts/` (`debug-boundaries.js`, `find-*.js`, `patch-*.js`, etc.) -- these are personal scratch tooling, not shipped code, not part of tests or the install path.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run compile` clean
- [x] Full regression suite: 138/138 passed