### PR TITLE
fix(#667): doc-auditor false-positive heuristics

### DIFF
--- a/src/features/doc-auditor/analyzer.ts
+++ b/src/features/doc-auditor/analyzer.ts
@@ -22,14 +22,24 @@ const GLOBAL_CANDIDATE_PATTERNS = [
     /^ONBOARDING/i,        /^COPILOT.?RULES/i, /^GLOBAL/i, /^STANDARDS/i,
 ];
 
+// Requires the global-standard language to appear in a normative sentence ABOUT the file
+// itself (e.g. "this document applies to all projects"), not just anywhere in the body —
+// otherwise a doc merely *mentioning* "all projects" in an unrelated sentence (e.g.
+// describing a feature that operates across projects) false-positives. See #667.
+const SELF_REFERENTIAL_GLOBAL_RE =
+    /\b(this (document|standard|guide|file|policy)|these (rules|standards|laws|guidelines))\b[\s\S]{0,80}?\b(applies?|apply) to (all projects|every project)\b|\bglobal standard\b[\s\S]{0,40}\bfor all projects\b/i;
+
 export function isGlobalCandidate(file: DocFile): string | undefined {
     if (file.projectName === 'global') { return undefined; }
-    for (const p of GLOBAL_CANDIDATE_PATTERNS) {
-        if (p.test(file.fileName)) { return `Filename "${file.fileName}" matches a global standards pattern`; }
+    const filenameMatches = GLOBAL_CANDIDATE_PATTERNS.some(p => p.test(file.fileName));
+    const contentConfirms = SELF_REFERENTIAL_GLOBAL_RE.test(file.content);
+    // Filename pattern alone is too weak a signal (e.g. TIER1-LAWS.md that's genuinely
+    // project-specific) — require corroborating self-referential content evidence.
+    if (filenameMatches && contentConfirms) {
+        return `Filename "${file.fileName}" matches a global standards pattern, and content confirms project-wide applicability`;
     }
-    if (file.content.includes('all projects') || file.content.includes('every project') ||
-        file.content.includes('global standard')) {
-        return 'Content uses global-standard language ("all projects", "global standard")';
+    if (contentConfirms) {
+        return 'Content declares itself as a global standard applying to all projects';
     }
     return undefined;
 }
@@ -39,6 +49,16 @@ export const PER_PROJECT_EXEMPT = new Set([
     'claude.md', 'readme.md', 'changelog.md', 'license.md', 'license',
     'contributing.md', 'security.md', 'code_of_conduct.md',
 ]);
+
+// "container" projects (lightweight organizational folders like `samples`, `tooling`,
+// `settings`) deliberately ship near-identical boilerplate CLAUDE.md/README.md placeholders
+// — these are expected, not real duplicates. See #667.
+const CONTAINER_BOILERPLATE_FILES = new Set(['claude.md', 'readme.md']);
+
+/** True if `doc` is an expected-identical boilerplate file from a "container" project. */
+export function isContainerBoilerplate(doc: DocFile): boolean {
+    return doc.projectStatus === 'container' && CONTAINER_BOILERPLATE_FILES.has(doc.fileName.toLowerCase());
+}
 
 /** Filter a byName map into duplicate groups, respecting per-project exemptions. */
 export function filterDuplicates(byName: Map<string, DocFile[]>): Array<{ fileName: string; files: DocFile[] }> {

--- a/src/features/doc-auditor/runner.ts
+++ b/src/features/doc-auditor/runner.ts
@@ -5,15 +5,13 @@
 
 import * as vscode from 'vscode';
 import * as fs     from 'fs';
-import * as path   from 'path';
 import { log }     from '../../shared/output-channel';
 import { loadRegistry } from '../../shared/registry';
 import { collectDocs }  from './scanner';
-import { computeSimilarity, isGlobalCandidate, isOrphan, filterDuplicates } from './analyzer';
+import { computeSimilarity, isGlobalCandidate, isOrphan, filterDuplicates, isContainerBoilerplate } from './analyzer';
 import type { DocFile, AuditResults, MoveCandidate } from './types';
 
 const FEATURE = 'doc-auditor';
-const STANDARD_CLAUDE_PATH = 'C:\\Users\\jwpmi\\Downloads\\VSCode\\projects\\cielovista-tools\\CLAUDE.md';
 
 export interface AuditProgressReporter {
     report(message: string): void;
@@ -23,17 +21,6 @@ export async function runAudit(progressReporter?: AuditProgressReporter): Promis
     const report = (message: string): void => {
         progressReporter?.report(message);
     };
-
-    // Load the standard CLAUDE.md for drift-detection
-    let standardClaude: DocFile | undefined;
-    if (fs.existsSync(STANDARD_CLAUDE_PATH)) {
-        const content = fs.readFileSync(STANDARD_CLAUDE_PATH, 'utf8');
-        standardClaude = {
-            filePath: STANDARD_CLAUDE_PATH, fileName: 'CLAUDE.md', projectName: 'global',
-            sizeBytes: Buffer.byteLength(content, 'utf8'), content,
-            normalized: content.toLowerCase().replace(/\s+/g, ' ').replace(/[#*`_\[\]()]/g, '').trim(),
-        };
-    }
 
     const registry = loadRegistry();
     if (!registry) { return undefined; }
@@ -51,7 +38,7 @@ export async function runAudit(progressReporter?: AuditProgressReporter): Promis
                 report(scanMessage);
                 progress.report({ message: scanMessage });
                 if (fs.existsSync(project.path)) {
-                    const projectDocs = collectDocs(project.path, project.name);
+                    const projectDocs = collectDocs(project.path, project.name, project.status);
                     allDocs.push(...projectDocs);
                     const countedMessage = `Audited ${allDocs.length} docs… (${project.name})`;
                     report(countedMessage);
@@ -60,9 +47,12 @@ export async function runAudit(progressReporter?: AuditProgressReporter): Promis
             }
             log(FEATURE, `Collected ${allDocs.length} docs`);
 
-            // 1 — duplicates (per-project files like CLAUDE.md are exempt from cross-project flagging)
+            // 1 — duplicates (per-project files like CLAUDE.md are exempt from cross-project flagging;
+            // "container" projects' boilerplate CLAUDE.md/README.md are deliberately near-identical
+            // placeholders, not real duplicates — see #667)
             const byName = new Map<string, DocFile[]>();
             for (const doc of allDocs) {
+                if (isContainerBoilerplate(doc)) { continue; }
                 const key = doc.fileName.toLowerCase();
                 if (!byName.has(key)) { byName.set(key, []); }
                 byName.get(key)!.push(doc);
@@ -90,18 +80,16 @@ export async function runAudit(progressReporter?: AuditProgressReporter): Promis
             }
             similar.sort((a, b) => b.similarity - a.similarity);
 
-            // 3 — move candidates + CLAUDE.md drift
+            // 3 — move candidates
+            // NOTE: this used to also flag cross-project "CLAUDE.md drift" against cielovista-tools'
+            // own CLAUDE.md as the "standard" — dropped entirely (#667): CLAUDE.md is inherently
+            // project-specific, and the old check flagged 21/22 real projects as needing to be
+            // overwritten with cielovista-tools' own unrelated instructions.
             report('Checking for misplaced docs…');
             progress.report({ message: 'Checking for misplaced docs…' });
             const moveCandidates: MoveCandidate[] = [];
             const warningCandidates: MoveCandidate[] = [];
             for (const doc of allDocs) {
-                if (doc.fileName.toLowerCase() === 'claude.md' && standardClaude && doc.projectName !== 'global') {
-                    if (computeSimilarity(doc.normalized, standardClaude.normalized) < 0.95) {
-                        warningCandidates.push({ file: doc, reason: '⚠️ This CLAUDE.md differs from the standard. You can overwrite it.' });
-                        continue;
-                    }
-                }
                 const reason = isGlobalCandidate(doc);
                 if (reason) { moveCandidates.push({ file: doc, reason }); }
             }

--- a/src/features/doc-auditor/scanner.ts
+++ b/src/features/doc-auditor/scanner.ts
@@ -10,7 +10,7 @@ import type { DocFile } from './types';
 const SKIP_DIRS = ['node_modules', '.git', 'out', 'dist', '.vscode', '.claude'];
 
 /** Returns all markdown docs under a directory tree (max 3 levels deep). */
-export function collectDocs(rootPath: string, projectName: string, maxDepth = 3): DocFile[] {
+export function collectDocs(rootPath: string, projectName: string, projectStatus?: string, maxDepth = 3): DocFile[] {
     const results: DocFile[] = [];
 
     function walk(dir: string, depth: number): void {
@@ -29,7 +29,7 @@ export function collectDocs(rootPath: string, projectName: string, maxDepth = 3)
                     const content    = fs.readFileSync(fullPath, 'utf8');
                     const stat       = fs.statSync(fullPath);
                     const normalized = content.toLowerCase().replace(/\s+/g, ' ').replace(/[#*`_\[\]()]/g, '').trim();
-                    results.push({ filePath: fullPath, fileName: entry.name, projectName,
+                    results.push({ filePath: fullPath, fileName: entry.name, projectName, projectStatus,
                                    sizeBytes: Buffer.byteLength(content, 'utf8'),
                                    modifiedAt: stat.mtime.toISOString(),
                                    content, normalized });

--- a/src/features/doc-auditor/types.ts
+++ b/src/features/doc-auditor/types.ts
@@ -4,13 +4,15 @@
 // component: aud
 
 export interface DocFile {
-    filePath:    string;
-    fileName:    string;
-    projectName: string;
-    sizeBytes:   number;
-    modifiedAt?: string;
-    content:     string;
-    normalized:  string;
+    filePath:      string;
+    fileName:      string;
+    projectName:   string;
+    /** Registry lifecycle status of the owning project (e.g. "container" for lightweight organizational folders). Undefined for global docs. */
+    projectStatus?: string;
+    sizeBytes:     number;
+    modifiedAt?:   string;
+    content:       string;
+    normalized:    string;
 }
 
 export interface DuplicateGroup {

--- a/tests/unit/doc-auditor-analyzer.test.js
+++ b/tests/unit/doc-auditor-analyzer.test.js
@@ -5,9 +5,10 @@
  * No vscode dependency — all three functions are pure.
  *
  * Covers:
- *   computeSimilarity()    — Jaccard word-overlap similarity score
- *   isGlobalCandidate()    — filename/content pattern matching
- *   isOrphan()             — cross-reference detection
+ *   computeSimilarity()      — Jaccard word-overlap similarity score
+ *   isGlobalCandidate()      — filename/content pattern matching
+ *   isOrphan()               — cross-reference detection
+ *   isContainerBoilerplate() — container-project boilerplate exemption (#667)
  *
  * Run: node tests/unit/doc-auditor-analyzer.test.js
  */
@@ -23,7 +24,7 @@ if (!fs.existsSync(OUT)) {
     process.exit(0);
 }
 
-const { computeSimilarity, isGlobalCandidate, isOrphan } = require(OUT);
+const { computeSimilarity, isGlobalCandidate, isOrphan, isContainerBoilerplate } = require(OUT);
 
 let passed = 0, failed = 0;
 
@@ -122,62 +123,89 @@ test('returns undefined for global project docs (already global)', () => {
     eq(isGlobalCandidate(doc), undefined, 'Global-project docs must never be flagged');
 });
 
-test('flags CODING-STANDARDS.md by filename pattern', () => {
-    const doc = makeDoc({ projectName: 'myProject', fileName: 'CODING-STANDARDS.md', content: '' });
-    ok(isGlobalCandidate(doc) !== undefined, 'CODING-STANDARDS.md must be flagged');
+// #667 regression: a suspicious filename ALONE (e.g. wb-starter's TIER1-LAWS.md, which is
+// genuinely project-specific despite its generic-sounding name) must not be flagged without
+// corroborating self-referential content.
+test('does NOT flag TIER1-LAWS.md by filename alone when content is project-specific', () => {
+    const doc = makeDoc({
+        projectName: 'myProject', fileName: 'TIER1-LAWS.md',
+        content: 'These are the non-negotiable rules for the WB-Starter project.',
+    });
+    eq(isGlobalCandidate(doc), undefined, 'Filename pattern alone must not trigger without content corroboration');
 });
 
-test('flags JAVASCRIPT-STANDARDS.md by filename pattern', () => {
-    const doc = makeDoc({ projectName: 'myProject', fileName: 'JAVASCRIPT-STANDARDS.md', content: '' });
+test('flags CODING-STANDARDS.md when content also confirms project-wide applicability', () => {
+    const doc = makeDoc({
+        projectName: 'myProject', fileName: 'CODING-STANDARDS.md',
+        content: 'This standard applies to all projects across the organization.',
+    });
+    ok(isGlobalCandidate(doc) !== undefined, 'CODING-STANDARDS.md with corroborating content must be flagged');
+});
+
+test('flags JAVASCRIPT-STANDARDS.md when content also confirms project-wide applicability', () => {
+    const doc = makeDoc({
+        projectName: 'myProject', fileName: 'JAVASCRIPT-STANDARDS.md',
+        content: 'This document applies to all projects.',
+    });
     ok(isGlobalCandidate(doc) !== undefined);
 });
 
-test('flags GIT-WORKFLOW.md by filename pattern', () => {
+test('does NOT flag GIT-WORKFLOW.md when content is empty/unrelated', () => {
     const doc = makeDoc({ projectName: 'myProject', fileName: 'GIT-WORKFLOW.md', content: '' });
-    ok(isGlobalCandidate(doc) !== undefined);
+    eq(isGlobalCandidate(doc), undefined, 'Filename alone is too weak a signal (#667)');
 });
 
-test('flags ARCHITECTURE-PRINCIPLES.md by filename pattern', () => {
+test('does NOT flag ARCHITECTURE-PRINCIPLES.md when content is empty/unrelated', () => {
     const doc = makeDoc({ projectName: 'myProject', fileName: 'ARCHITECTURE-PRINCIPLES.md', content: '' });
-    ok(isGlobalCandidate(doc) !== undefined);
+    eq(isGlobalCandidate(doc), undefined);
 });
 
-test('flags ONBOARDING.md by filename pattern', () => {
+test('does NOT flag ONBOARDING.md when content is empty/unrelated', () => {
     const doc = makeDoc({ projectName: 'myProject', fileName: 'ONBOARDING.md', content: '' });
-    ok(isGlobalCandidate(doc) !== undefined);
+    eq(isGlobalCandidate(doc), undefined);
 });
 
-test('flags doc with "all projects" in content', () => {
+// #667 regression: docs/ViewADoc.md was flagged because "global standards folder" contains
+// "global standard" as a raw substring, and mentioning a feature that works "across all
+// registered projects" is not the same as the file declaring itself a global standard.
+test('does NOT flag a doc merely mentioning "global standards folder" in passing', () => {
+    const doc = makeDoc({
+        projectName: 'myProject', fileName: 'ViewADoc.md',
+        content: 'A searchable catalog of docs across all registered projects and the global standards folder.',
+    });
+    eq(isGlobalCandidate(doc), undefined, 'Passing mention must not trigger — no self-referential claim');
+});
+
+test('flags doc with a self-referential "applies to all projects" sentence', () => {
     const doc = makeDoc({
         projectName: 'myProject', fileName: 'notes.md',
-        content: 'This applies to all projects in the organization.',
+        content: 'This document applies to all projects in the organization.',
     });
-    ok(isGlobalCandidate(doc) !== undefined, 'Content with "all projects" must be flagged');
+    ok(isGlobalCandidate(doc) !== undefined, 'Self-referential "applies to all projects" must be flagged');
 });
 
-test('flags doc with "global standard" in content', () => {
+test('flags doc that declares itself the global standard for all projects', () => {
     const doc = makeDoc({
         projectName: 'myProject', fileName: 'guide.md',
-        content: 'This is a global standard for how we build things.',
+        content: 'This is the global standard for all projects — follow it exactly.',
     });
     ok(isGlobalCandidate(doc) !== undefined);
 });
 
-test('flags doc with "every project" in content (case-sensitive lowercase)', () => {
+test('flags doc with "these rules apply to every project"', () => {
     const doc = makeDoc({
         projectName: 'myProject', fileName: 'rules.md',
-        content: 'every project must follow these naming conventions.',
+        content: 'These rules apply to every project in the organization.',
     });
     ok(isGlobalCandidate(doc) !== undefined);
 });
 
-test('does NOT flag doc with "Every project" (capital E — case-sensitive check)', () => {
+test('does NOT flag a doc that mentions "every project" without self-referential framing', () => {
     const doc = makeDoc({
         projectName: 'myProject', fileName: 'rules.md',
         content: 'Every project must follow these naming conventions.',
     });
-    // Source uses case-sensitive includes — capital E does not match
-    eq(isGlobalCandidate(doc), undefined, 'Capital-E Every project does not trigger flag (known limitation)');
+    eq(isGlobalCandidate(doc), undefined, 'Bare mention without a self-referential claim must not trigger');
 });
 
 test('returns undefined for ordinary project doc', () => {
@@ -188,9 +216,9 @@ test('returns undefined for ordinary project doc', () => {
     eq(isGlobalCandidate(doc), undefined, 'Ordinary project doc must not be flagged');
 });
 
-test('flags STANDARDS.md by filename pattern', () => {
+test('does NOT flag STANDARDS.md when content is unrelated', () => {
     const doc = makeDoc({ projectName: 'myProject', fileName: 'STANDARDS.md', content: 'hello' });
-    ok(isGlobalCandidate(doc) !== undefined);
+    eq(isGlobalCandidate(doc), undefined);
 });
 
 // ═══════════════════════════════════════════════════════════
@@ -244,6 +272,40 @@ test('doc does not flag itself as its own reference', () => {
     const doc = makeDoc({ fileName: 'solo.md', filePath: '/proj/solo.md', content: 'See solo.md itself' });
     const reason = isOrphan(doc, [doc]); // only doc in collection
     ok(reason !== undefined, 'Self-reference must not count; still flagged if no OTHER doc links to it');
+});
+
+// \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550
+// isContainerBoilerplate()  (#667)
+// \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550
+console.log('\n-- isContainerBoilerplate() --');
+
+test('flags CLAUDE.md from a container project as boilerplate', () => {
+    const doc = makeDoc({ fileName: 'CLAUDE.md', projectName: 'samples' });
+    doc.projectStatus = 'container';
+    ok(isContainerBoilerplate(doc), 'container-project CLAUDE.md must be treated as boilerplate');
+});
+
+test('flags README.md from a container project as boilerplate (case-insensitive)', () => {
+    const doc = makeDoc({ fileName: 'Readme.md', projectName: 'tooling' });
+    doc.projectStatus = 'container';
+    ok(isContainerBoilerplate(doc));
+});
+
+test('does NOT flag CLAUDE.md from a non-container project', () => {
+    const doc = makeDoc({ fileName: 'CLAUDE.md', projectName: 'realProduct' });
+    doc.projectStatus = 'product';
+    eq(isContainerBoilerplate(doc), false);
+});
+
+test('does NOT flag a non-boilerplate file even from a container project', () => {
+    const doc = makeDoc({ fileName: 'notes.md', projectName: 'samples' });
+    doc.projectStatus = 'container';
+    eq(isContainerBoilerplate(doc), false, 'Only CLAUDE.md/README.md are exempt, not arbitrary docs');
+});
+
+test('does NOT flag when projectStatus is undefined', () => {
+    const doc = makeDoc({ fileName: 'CLAUDE.md', projectName: 'unknown' });
+    eq(isContainerBoilerplate(doc), false);
 });
 
 console.log('\n' + '\u2500'.repeat(50));


### PR DESCRIPTION
## Summary
Fixes #667 -- three false-positive/destructive heuristics in `src/features/doc-auditor/`, confirmed by running the audit against the real 22-project registry:

1. **CLAUDE.md drift check dropped entirely.** It compared every project's CLAUDE.md against cielovista-tools' own as "the standard" and suggested overwriting the 21/22 that differed. CLAUDE.md is inherently project-specific by design.
2. **Container-project boilerplate exemption.** "container" projects (`samples`, `tooling`, `settings`, etc.) ship deliberately near-identical placeholder CLAUDE.md/README.md files -- these were flagged as duplicates needing consolidation. Threads `project.status` through to `DocFile` and adds a pure `isContainerBoilerplate()` helper to exempt them.
3. **Stricter global-candidate matching.** The old content check used naive substring matching (`"global standard"` matched inside `"global standards folder"` in an unrelated sentence -- this is what actually flagged `docs/ViewADoc.md`, not `"all projects"` as originally suspected). The filename-pattern branch had zero content corroboration, flagging wb-starter's genuinely project-specific `TIER1-LAWS.md` purely by its generic-sounding name. Now requires the global-standard language to appear in a self-referential sentence about the file itself, and requires filename matches to be corroborated by content.

Depends on #675 for the registry `status` type including `'container'` (this PR still compiles standalone since the new param is loosely typed `string`, but the container-exemption logic won't actually trigger real container projects until #675 lands too).

## Test plan
- [x] Added `isContainerBoilerplate()` + rewrote `isGlobalCandidate()` test coverage, directly regression-testing the 3 documented false positives (TIER1-LAWS.md, ViewADoc.md, cross-project CLAUDE.md)
- [x] `tsc --noEmit` clean
- [x] `npm run compile` clean
- [x] `doc-auditor-analyzer.test.js`: 35/35 passed
- [x] `doc-auditor-scanner.test.js`, `doc-auditor-duplicates.test.js`, `doc-auditor-html.test.js`: all passed
- [x] Full regression suite: 138/138 passed